### PR TITLE
Revert to Datadog Packages key 4172a230

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -16,7 +16,7 @@
 #
 class datadog_agent::redhat(
   $baseurl = "https://yum.datadoghq.com/rpm/${::architecture}/",
-  $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+  $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
   $manage_repo = true,
   $agent_version = 'latest'
 ) {
@@ -37,7 +37,7 @@ class datadog_agent::redhat(
 
     exec { 'install-gpg-key':
         command => "/bin/rpm --import ${public_key_local}",
-        onlyif  => "/usr/bin/gpg --quiet --with-fingerprint -n ${public_key_local} | grep \'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3\'",
+        onlyif  => "/usr/bin/gpg --quiet --with-fingerprint -n ${public_key_local} | grep \'60A3 89A4 4A0C 32BA E3C0  3F0B 069B 56F5 4172 A230\'",
         unless  => '/bin/rpm -q gpg-pubkey-e09422b3',
         require => Remote_file['DATADOG_RPM_KEY.public'],
         notify  => Exec['cleanup-gpg-key'],

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -16,7 +16,7 @@ describe 'datadog_agent::redhat' do
       should contain_yumrepo('datadog')
         .with_enabled(1)\
         .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
         .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
     end
   end


### PR DESCRIPTION
For Issue #270

- Revert RPM key changes to specify the current package signing key
- Update spec test to match