### PR TITLE
Gem fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 before_install: rm -f Gemfile.lock
 sudo: false
+bundler_args: --full-index
 cache: bundler
 rvm:
   - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,6 @@ group :development do
   gem "beaker", '2.51.0'
   gem "beaker-rspec"
   gem "puppet-blacksmith"
+  gem "nokogiri", "~> 1.6.0"
   gem "guard-rake"
 end


### PR DESCRIPTION
This changes adds versioning of the nokogiri gem.

The module tests run puppet-blacksmith which requires the nokogiri gem.
The nokogiri 1.7.0 requires Ruby 2.1.0 which is why the Ruby 2.0.0 tests were failing.

