### PR TITLE
Update Datadog puppet module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,4 +9,5 @@ fixtures:
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
     remote_file: "git://github.com/lwf/puppet-remote_file.git"
   symlinks:
+    custom_datadog: "#{source_dir}/spec/custom_fixtures/custom_datadog"
     datadog_agent: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,7 @@ fixtures:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref: "4.12.0"
+    concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
     remote_file: "git://github.com/lwf/puppet-remote_file.git"
   symlinks:

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,9 @@ fixtures:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref: "4.12.0"
-    concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
+    concat:
+      repo: "git://github.com/puppetlabs/puppetlabs-concat.git"
+      ref: "2.2.0"
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
     remote_file: "git://github.com/lwf/puppet-remote_file.git"
   symlinks:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ spec/fixtures
 .rspec_system
 .bundle
 vendor
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ bundler_args: --full-index
 cache: bundler
 rvm:
   - 2.0.0
-  - 2.1.0
+  - 2.1.1
   - 2.2.3
 script:
   - bundle exec rake spec
@@ -30,14 +30,14 @@ matrix:
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 2.7.0"
 
-  # Ruby 2.1.0
-  - rvm: 2.1.0
+  # Ruby 2.1.1
+  - rvm: 2.1.1
     env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
+  - rvm: 2.1.1
     env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
+  - rvm: 2.1.1
     env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
+  - rvm: 2.1.1
     env: PUPPET_VERSION="~> 3.4.0"
 
   # Ruby 2.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changes
 =======
 
-# 1.11.0 / Unreleased
+# 1.11.0 / 2017-07-27
 
 ### Notes
 
@@ -25,6 +25,7 @@ Changes
 * [BUGFIX] RHEL/CentOS: fix chatty behavior. See [#341][]
 * [BUGFIX] Dd-agent: ensured etc/dd-agent is directory. See [#332][] (Thanks [@butangero][])
 
+* [SANITY] Metadata: set correct apache license ID.
 
 # 1.10.0 / 2017-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changes
 =======
 
-# 1.10.0 / Unreleased
+# 1.10.0 / 2017-04-21
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 Changes
 =======
 
+# 1.11.0 / Unreleased
+
+### Notes
+
+* [FEATURE] Postfix Added integration. See [#323][] (Thanks [@npaufler][])
+* [FEATURE] Twemproxy: Added integration. See [#326][] (Thanks [@swwolf][])
+* [FEATURE] HAproxy: Added integration. See [#326][] (Thanks [@swwolf][])
+
+* [IMPROVEMENT] Memcache: Add multi-instance support for memcache. See [#318][] (Thanks [@npaufler][])
+* [IMPROVEMENT] Elasticsearch: Add support for multiple instances. See [#333][] (Thanks [@stantona][])
+* [IMPROVEMENT] Mongodb: support collection metrics per collection. See [#335][] (Thanks [@jensendw][])
+* [IMPROVEMENT] Redis: Allow command_stats. See [#327][] (Thanks [@IanCrouch][])
+* [IMPROVEMENT] Ceph: Add parameters to integration. See [#322][] (Thanks [@stamak][])
+* [IMPROVEMENT] Ubuntu: apt make repository configurable. See [#340][]
+* [IMPROVEMENT] Ubuntu: use full key ID when adding GPG keys. See [#329][] (Thanks [@pid1][])
+* [IMPROVEMENT] Dd-agent: Change owner/group of /etc/dd-agent. See [#325][] (Thanks [@ColinHebert][])
+* [IMPROVEMENT] Docker_daemon: remove spaces that break resulting yaml. See [#336][] (Thanks [@ckolos][])
+
+* [BUGFIX] Dd-agent: add extra_template back. See [#331][] (Thanks [@flyinprogrammer][])
+* [BUGFIX] Dd-agent: Don't fail if there is no value in hiera. See [#334][] (Thanks [@mtougeron][])
+* [BUGFIX] Core: Addressing metaparam override in datadog_agent::tag. See [#338][] (Thanks [@craigwatson][])
+* [BUGFIX] RHEL/CentOS: fix chatty behavior. See [#341][]
+* [BUGFIX] Dd-agent: ensured etc/dd-agent is directory. See [#332][] (Thanks [@butangero][])
+
+
 # 1.10.0 / 2017-04-21
 
 ### Notes
@@ -313,7 +338,24 @@ Changes
 [#311]: https://github.com/DataDog/puppet-datadog-agent/issues/311
 [#313]: https://github.com/DataDog/puppet-datadog-agent/issues/313
 [#315]: https://github.com/DataDog/puppet-datadog-agent/issues/315
+[#318]: https://github.com/DataDog/puppet-datadog-agent/issues/318
+[#322]: https://github.com/DataDog/puppet-datadog-agent/issues/322
+[#323]: https://github.com/DataDog/puppet-datadog-agent/issues/323
+[#325]: https://github.com/DataDog/puppet-datadog-agent/issues/325
+[#326]: https://github.com/DataDog/puppet-datadog-agent/issues/326
+[#327]: https://github.com/DataDog/puppet-datadog-agent/issues/327
+[#329]: https://github.com/DataDog/puppet-datadog-agent/issues/329
+[#331]: https://github.com/DataDog/puppet-datadog-agent/issues/331
+[#332]: https://github.com/DataDog/puppet-datadog-agent/issues/332
+[#333]: https://github.com/DataDog/puppet-datadog-agent/issues/333
+[#334]: https://github.com/DataDog/puppet-datadog-agent/issues/334
+[#335]: https://github.com/DataDog/puppet-datadog-agent/issues/335
+[#336]: https://github.com/DataDog/puppet-datadog-agent/issues/336
+[#338]: https://github.com/DataDog/puppet-datadog-agent/issues/338
+[#340]: https://github.com/DataDog/puppet-datadog-agent/issues/340
+[#341]: https://github.com/DataDog/puppet-datadog-agent/issues/341
 [@BIAndrews]: https://github.com/BIAndrews
+[@ColinHebert]: https://github.com/ColinHebert
 [@DDRBoxman]: https://github.com/DDRBoxman
 [@IanCrouch]: https://github.com/IanCrouch
 [@LeoCavaille]: https://github.com/LeoCavaille
@@ -326,6 +368,8 @@ Changes
 [@b2jrock]: https://github.com/b2jrock
 [@bflad]: https://github.com/bflad
 [@binford2k]: https://github.com/binford2k
+[@butangero]: https://github.com/butangero
+[@ckolos]: https://github.com/ckolos
 [@craigwatson]: https://github.com/craigwatson
 [@cristianjuve]: https://github.com/cristianjuve
 [@cwood]: https://github.com/cwood
@@ -342,20 +386,25 @@ Changes
 [@jacobbednarz]: https://github.com/jacobbednarz
 [@jangie]: https://github.com/jangie
 [@jdavisp3]: https://github.com/jdavisp3
+[@jensendw]: https://github.com/jensendw
 [@jniesen]: https://github.com/jniesen
 [@kitchen]: https://github.com/kitchen
 [@mcasper]: https://github.com/mcasper
 [@mraylu]: https://github.com/mraylu
 [@mrunkel-ut]: https://github.com/mrunkel-ut
+[@mtougeron]: https://github.com/mtougeron
+[@npaufler]: https://github.com/npaufler
 [@obi11235]: https://github.com/obi11235
 [@obowersa]: https://github.com/obowersa
 [@pabrahamsson]: https://github.com/pabrahamsson
+[@pid1]: https://github.com/pid1
 [@rooprob]: https://github.com/rooprob
 [@rtyler]: https://github.com/rtyler
 [@sambanks]: https://github.com/sambanks
 [@scottgeary]: https://github.com/scottgeary
 [@sethcleveland]: https://github.com/sethcleveland
 [@stamak]: https://github.com/stamak
+[@stantona]: https://github.com/stantona
 [@swwolf]: https://github.com/swwolf
 [@tdm4]: https://github.com/tdm4
 [@tuxinaut]: https://github.com/tuxinaut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 Changes
 =======
 
+# 1.10.0 / Unreleased
+
+### Notes
+
+* [FEATURE] Ceph: Adding integration. See [#293][] (Thanks [@stamak][])
+* [FEATURE] Tcp_check: Adding integration. See [#286][] (Thanks [@aepod][])
+* [FEATURE] Trace_agent: Configure APM trace agent. See [#302][] and [#311][] (Thanks [@DDRBoxman][])
+* [FEATURE] Allow hiera defined integrations. See [#261][] (Thanks [@cwood][])
+
+* [IMPROVEMENT] Make tags their own resource. See [#261][] (Thanks [@cwood][])
+* [IMPROVEMENT] Support ports as integers. See [#315][] (Thanks [@alexharv074][])
+* [IMPROVEMENT] PHPfpm: Support for multiple instances and `http_host`. See [#299][] (Thanks [@obi11235][])
+* [IMPROVEMENT] RabbitMQ: Adding additional configuration parameters. See [#288][] (Thanks [@alvin-huang][])
+* [IMPROVEMENT] Http_check: Adding response_status_code. See [#290][] (Thanks [@dzinek][])
+* [IMPROVEMENT] Http_check: Adding no_proxy configuration option. See [#309][]
+* [IMPROVEMENT] Service_discovery: Adding jmx checks for SD. See [#296][] (Thanks [@alvin-huang][])
+* [IMPROVEMENT] Reporting: Fix already initialized warning. See [#292][] and [#310][] (Thanks [@craigwatson][])
+* [IMPROVEMENT] Reporting: Send metrics for hosts as a batch, reducing overhead. See [#313][] (Thanks [@tdm4][])
+
+* [DEPRECATE] Http_check: Slowly deprecate skip_event. See [#291][] (Thanks [@flyinprogrammer][])
+
+* [DOCUMENTATION] Cleanup EC2-related parameter docs. See [#252][] (Thanks [@jdavisp3][])
+* [DOCUMENTATION] Zookeeper: fix comment to match reality. See [#297][] (Thanks [@generica][])
+
+
 # 1.9.0 / 2016-12-20
 
 ### Notes
@@ -258,9 +283,11 @@ Changes
 [#242]: https://github.com/DataDog/puppet-datadog-agent/issues/242
 [#243]: https://github.com/DataDog/puppet-datadog-agent/issues/243
 [#247]: https://github.com/DataDog/puppet-datadog-agent/issues/247
+[#252]: https://github.com/DataDog/puppet-datadog-agent/issues/252
 [#256]: https://github.com/DataDog/puppet-datadog-agent/issues/256
 [#258]: https://github.com/DataDog/puppet-datadog-agent/issues/258
 [#259]: https://github.com/DataDog/puppet-datadog-agent/issues/259
+[#261]: https://github.com/DataDog/puppet-datadog-agent/issues/261
 [#263]: https://github.com/DataDog/puppet-datadog-agent/issues/263
 [#264]: https://github.com/DataDog/puppet-datadog-agent/issues/264
 [#266]: https://github.com/DataDog/puppet-datadog-agent/issues/266
@@ -271,33 +298,56 @@ Changes
 [#281]: https://github.com/DataDog/puppet-datadog-agent/issues/281
 [#282]: https://github.com/DataDog/puppet-datadog-agent/issues/282
 [#283]: https://github.com/DataDog/puppet-datadog-agent/issues/283
+[#286]: https://github.com/DataDog/puppet-datadog-agent/issues/286
+[#288]: https://github.com/DataDog/puppet-datadog-agent/issues/288
+[#290]: https://github.com/DataDog/puppet-datadog-agent/issues/290
+[#291]: https://github.com/DataDog/puppet-datadog-agent/issues/291
+[#292]: https://github.com/DataDog/puppet-datadog-agent/issues/292
+[#293]: https://github.com/DataDog/puppet-datadog-agent/issues/293
+[#296]: https://github.com/DataDog/puppet-datadog-agent/issues/296
+[#297]: https://github.com/DataDog/puppet-datadog-agent/issues/297
+[#299]: https://github.com/DataDog/puppet-datadog-agent/issues/299
+[#302]: https://github.com/DataDog/puppet-datadog-agent/issues/302
+[#309]: https://github.com/DataDog/puppet-datadog-agent/issues/309
+[#310]: https://github.com/DataDog/puppet-datadog-agent/issues/310
+[#311]: https://github.com/DataDog/puppet-datadog-agent/issues/311
+[#313]: https://github.com/DataDog/puppet-datadog-agent/issues/313
+[#315]: https://github.com/DataDog/puppet-datadog-agent/issues/315
 [@BIAndrews]: https://github.com/BIAndrews
+[@DDRBoxman]: https://github.com/DDRBoxman
 [@IanCrouch]: https://github.com/IanCrouch
 [@LeoCavaille]: https://github.com/LeoCavaille
 [@MartinDelta]: https://github.com/MartinDelta
 [@NoodlesNZ]: https://github.com/NoodlesNZ
 [@aaron-miller]: https://github.com/aaron-miller
 [@aepod]: https://github.com/aepod
+[@alexharv074]: https://github.com/alexharv074
+[@alvin-huang]: https://github.com/alvin-huang
 [@b2jrock]: https://github.com/b2jrock
 [@bflad]: https://github.com/bflad
 [@binford2k]: https://github.com/binford2k
+[@craigwatson]: https://github.com/craigwatson
 [@cristianjuve]: https://github.com/cristianjuve
 [@cwood]: https://github.com/cwood
 [@davejrt]: https://github.com/davejrt
 [@davidgibbons]: https://github.com/davidgibbons
 [@degemer]: https://github.com/degemer
 [@denmat]: https://github.com/denmat
+[@dzinek]: https://github.com/dzinek
 [@eddmann]: https://github.com/eddmann
 [@flyinprogrammer]: https://github.com/flyinprogrammer
 [@fzwart]: https://github.com/fzwart
+[@generica]: https://github.com/generica
 [@grubernaut]: https://github.com/grubernaut
 [@jacobbednarz]: https://github.com/jacobbednarz
 [@jangie]: https://github.com/jangie
+[@jdavisp3]: https://github.com/jdavisp3
 [@jniesen]: https://github.com/jniesen
 [@kitchen]: https://github.com/kitchen
 [@mcasper]: https://github.com/mcasper
 [@mraylu]: https://github.com/mraylu
 [@mrunkel-ut]: https://github.com/mrunkel-ut
+[@obi11235]: https://github.com/obi11235
 [@obowersa]: https://github.com/obowersa
 [@pabrahamsson]: https://github.com/pabrahamsson
 [@rooprob]: https://github.com/rooprob
@@ -305,5 +355,7 @@ Changes
 [@sambanks]: https://github.com/sambanks
 [@scottgeary]: https://github.com/scottgeary
 [@sethcleveland]: https://github.com/sethcleveland
+[@stamak]: https://github.com/stamak
 [@swwolf]: https://github.com/swwolf
+[@tdm4]: https://github.com/tdm4
 [@tuxinaut]: https://github.com/tuxinaut

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem "syck"
   gem "safe_yaml", "~> 1.0.4"
+  gem "hiera-eyaml", "~> 2.1.0"
   gem "listen", "~> 3.0.0"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.2.0'
   gem "puppet-lint"

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ group :development do
   gem "beaker-rspec"
   gem "beaker", '2.51.0'
   gem "guard-rake"
-  gem "hiera-eyaml"
   gem "nokogiri", "~> 1.6.0"
   gem "puppet-blacksmith"
   gem "xmlrpc" if RUBY_VERSION >= '2.3'

--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,11 @@ group :test do
 end
 
 group :development do
-  gem "beaker", '2.51.0'
   gem "beaker-rspec"
-  gem "puppet-blacksmith"
-  gem "nokogiri", "~> 1.6.0"
+  gem "beaker", '2.51.0'
   gem "guard-rake"
+  gem "hiera-eyaml"
+  gem "nokogiri", "~> 1.6.0"
+  gem "puppet-blacksmith"
+  gem "xmlrpc" if RUBY_VERSION >= '2.3'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ end
 
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")
-PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.log_format = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
 
 # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.

--- a/files/datadog.list
+++ b/files/datadog.list
@@ -1,1 +1,0 @@
-deb https://apt.datadoghq.com/ stable main

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -108,13 +108,15 @@ Puppet::Reports.register_report(:datadog_reports) do
 
     Puppet.debug "Sending metrics for #{@msg_host} to Datadog"
     @dog = Dogapi::Client.new(API_KEY)
-    self.metrics.each { |metric,data|
-      data.values.each { |val|
-        name = "puppet.#{val[1].gsub(/ /, '_')}.#{metric}".downcase
-        value = val[2]
-        @dog.emit_point("#{name}", value, :host => "#{@msg_host}")
+    @dog.batch_metrics do
+      self.metrics.each { |metric,data|
+        data.values.each { |val|
+          name = "puppet.#{val[1].gsub(/ /, '_')}.#{metric}".downcase
+          value = val[2]
+          @dog.emit_point("#{name}", value, :host => "#{@msg_host}")
+        }
       }
-    }
+    end
 
     Puppet.debug "Sending events for #{@msg_host} to Datadog"
     @dog.emit_event(Dogapi::Event.new(event_data,

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -15,11 +15,11 @@ Puppet::Reports.register_report(:datadog_reports) do
   API_KEY = config[:datadog_api_key]
 
   # if need be initialize the regex
-  HOSTNAME_EXTRACTION_REGEX = config[:hostname_extraction_regex]
+  HOSTNAME_REGEX = config[:hostname_extraction_regex]
   begin
-    HOSTNAME_EXTRACTION_REGEX = Regexp.new HOSTNAME_EXTRACTION_REGEX unless HOSTNAME_EXTRACTION_REGEX.nil?
+    HOSTNAME_EXTRACTION_REGEX = Regexp.new HOSTNAME_REGEX unless HOSTNAME_REGEX.nil?
   rescue
-    raise(Puppet::ParseError, "Invalid hostname_extraction_regex #{HOSTNAME_EXTRACTION_REGEX}")
+    raise(Puppet::ParseError, "Invalid hostname_extraction_regex #{HOSTNAME_REGEX}")
   end
 
   desc <<-DESC

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -247,6 +247,16 @@ class datadog_agent(
   $apm_env = '',
 ) inherits datadog_agent::params {
 
+  # Allow ports to be passed as integers or strings.
+  # lint:ignore:only_variable_string
+  $_statsd_forward_port = "${statsd_forward_port}"
+  $_proxy_port = "${proxy_port}"
+  $_graphite_listen_port = "${graphite_listen_port}"
+  $_listen_port = "${listen_port}"
+  $_pup_port = "${pup_port}"
+  $_syslog_port = "${syslog_port}"
+  # lint:endignore
+
   validate_string($dd_url)
   validate_string($host)
   validate_string($api_key)
@@ -263,12 +273,12 @@ class datadog_agent(
   validate_string($log_level)
   validate_integer($dogstatsd_port)
   validate_string($statsd_histogram_percentiles)
-  validate_string($statsd_forward_port)
+  validate_re($_statsd_forward_port, '^\d*$')
   validate_string($proxy_host)
-  validate_string($proxy_port)
+  validate_re($_proxy_port, '^\d*$')
   validate_string($proxy_user)
   validate_string($proxy_password)
-  validate_string($graphite_listen_port)
+  validate_re($_graphite_listen_port, '^\d*$')
   validate_string($extra_template)
   validate_string($ganglia_host)
   validate_integer($ganglia_port)
@@ -278,11 +288,11 @@ class datadog_agent(
   validate_bool($collect_ec2_tags)
   validate_bool($collect_instance_metadata)
   validate_string($recent_point_threshold)
-  validate_string($listen_port)
+  validate_re($_listen_port, '^\d*$')
   validate_string($additional_checksd)
   validate_string($bind_host)
   validate_bool($use_pup)
-  validate_string($pup_port)
+  validate_re($_pup_port, '^\d*$')
   validate_string($pup_interface)
   validate_string($pup_url)
   validate_bool($use_dogstatsd)
@@ -297,7 +307,7 @@ class datadog_agent(
   validate_string($dogstatsd_log_file)
   validate_string($pup_log_file)
   validate_string($syslog_host)
-  validate_string($syslog_port)
+  validate_re($_syslog_port, '^\d*$')
   validate_string($service_discovery_backend)
   validate_string($sd_config_backend)
   validate_string($sd_backend_host)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,7 +151,9 @@
 #   $pup_log_file
 #       Specifies the log file location for the pup system
 #       String. Default: empty
-#
+#   $apm_enabled
+#       Boolean to enable or disable the trace agent
+#       Boolean. Default: false
 #
 # Actions:
 #
@@ -238,6 +240,7 @@ class datadog_agent(
   $package_name = $datadog_agent::params::package_name,
   $dd_user = $datadog_agent::params::dd_user,
   $dd_group = $datadog_agent::params::dd_group,
+  $apm_enabled = false,
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)
@@ -298,6 +301,7 @@ class datadog_agent(
   validate_string($sd_template_dir)
   validate_bool($sd_jmx_enable)
   validate_string($consul_token)
+  validate_bool($apm_enabled)
 
   if $hiera_tags {
     $local_tags = hiera_array('datadog_agent::tags')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -323,13 +323,13 @@ class datadog_agent(
   validate_string($apm_env)
 
   if $hiera_tags {
-    $local_tags = hiera_array('datadog_agent::tags')
+    $local_tags = hiera_array('datadog_agent::tags', [])
   } else {
     $local_tags = $tags
   }
 
   if $hiera_integrations {
-    $local_integrations = hiera_hash('datadog_agent::integrations')
+    $local_integrations = hiera_hash('datadog_agent::integrations', {})
   } else {
     $local_integrations = $integrations
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,6 +235,7 @@ class datadog_agent(
   $sd_backend_host = '',
   $sd_backend_port = 0,
   $sd_template_dir = '',
+  $sd_jmx_enable = false,
   $consul_token = '',
   $conf_dir = $datadog_agent::params::conf_dir,
   $service_name = $datadog_agent::params::service_name,
@@ -299,6 +300,7 @@ class datadog_agent(
   validate_string($sd_backend_host)
   validate_integer($sd_backend_port)
   validate_string($sd_template_dir)
+  validate_bool($sd_jmx_enable)
   validate_string($consul_token)
 
   if $hiera_tags {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -362,7 +362,7 @@ class datadog_agent(
   }
 
   file { '/etc/dd-agent':
-    ensure  => present,
+    ensure  => directory,
     owner   => $dd_user,
     group   => $dd_group,
     mode    => '0755',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -363,8 +363,8 @@ class datadog_agent(
 
   file { '/etc/dd-agent':
     ensure  => present,
-    owner   => 'root',
-    group   => 'root',
+    owner   => $dd_user,
+    group   => $dd_group,
     mode    => '0755',
     require => Package['datadog-agent'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,8 +11,10 @@
 #       Your DataDog API Key. Please replace with your key value.
 #   $collect_ec2_tags
 #       Collect AWS EC2 custom tags as agent tags.
+#       Boolean. Default: false
 #   $collect_instance_metadata
 #       The Agent will try to collect instance metadata for EC2 and GCE instances.
+#       Boolean. Default: true
 #   $tags
 #       Optional array of tags.
 #   $hiera_tags
@@ -73,12 +75,6 @@
 #       Skip SSL validation.
 #   $use_curl_http_client
 #       Uses the curl HTTP client for the forwarder
-#   $collect_ec2_tas
-#       Presents custom EC2 tags as agent tags to datadog
-#       Boolean. Default: False
-#   $collect_instance_metadata
-#       Enables the agent to try and gather instance metadata on EC2/GCE
-#       Boolean. Default: true
 #   $recent_point_threshold
 #       Sets the threshold for accepting points.
 #   String. Default: empty (30 second intervals)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -405,10 +405,21 @@ class datadog_agent(
     order   => '05',
   }
 
+  if ($extra_template != '') {
+    concat::fragment{ 'datadog extra_template footer':
+      target  => '/etc/dd-agent/datadog.conf',
+      content => template($extra_template),
+      order   => '06',
+    }
+    $apm_footer_order = '07'
+  } else {
+    $apm_footer_order = '06'
+  }
+
   concat::fragment{ 'datadog apm footer':
     target  => '/etc/dd-agent/datadog.conf',
     content => template('datadog_agent/datadog_apm_footer.conf.erb'),
-    order   => '06',
+    order   => $apm_footer_order,
   }
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -154,6 +154,9 @@
 #   $apm_enabled
 #       Boolean to enable or disable the trace agent
 #       Boolean. Default: false
+#   $apm_env
+#       String defining the environment for the APM traces
+#       String. Default: empty
 #
 # Actions:
 #
@@ -241,6 +244,7 @@ class datadog_agent(
   $dd_user = $datadog_agent::params::dd_user,
   $dd_group = $datadog_agent::params::dd_group,
   $apm_enabled = false,
+  $apm_env = '',
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)
@@ -302,6 +306,7 @@ class datadog_agent(
   validate_bool($sd_jmx_enable)
   validate_string($consul_token)
   validate_bool($apm_enabled)
+  validate_string($apm_env)
 
   if $hiera_tags {
     $local_tags = hiera_array('datadog_agent::tags')

--- a/manifests/integrations/ceph.pp
+++ b/manifests/integrations/ceph.pp
@@ -3,6 +3,10 @@
 # This class will install the necessary configuration for the ceph integration
 #
 # Parameters:
+#   $tags
+#       Optional array of tags
+#   $ceph_cmd
+#       Optional ceph cmd
 
 # Sample Usage:
 #
@@ -10,8 +14,12 @@
 #  }
 #
 class datadog_agent::integrations::ceph(
+  $tags = [ 'name:ceph_cluster' ],
+  $ceph_cmd = '/usr/bin/ceph',
 ) inherits datadog_agent::params {
   include datadog_agent
+
+  validate_array($tags)
 
   file { '/etc/sudoers.d/datadog_ceph':
     content => "# This file is required for dd ceph \ndd-agent ALL=(ALL) NOPASSWD:/usr/bin/ceph\n"

--- a/manifests/integrations/ceph.pp
+++ b/manifests/integrations/ceph.pp
@@ -1,0 +1,29 @@
+# Class: datadog_agent::integrations::ceph
+#
+# This class will install the necessary configuration for the ceph integration
+#
+# Parameters:
+
+# Sample Usage:
+#
+#  class { 'datadog_agent::integrations::ceph' :
+#  }
+#
+class datadog_agent::integrations::ceph(
+) inherits datadog_agent::params {
+  include datadog_agent
+
+  file { '/etc/sudoers.d/datadog_ceph':
+    content => "# This file is required for dd ceph \ndd-agent ALL=(ALL) NOPASSWD:/usr/bin/ceph\n"
+  }
+
+  file { "${datadog_agent::params::conf_dir}/ceph.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0600',
+    content => template('datadog_agent/agent-conf.d/ceph.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/manifests/integrations/haproxy.pp
+++ b/manifests/integrations/haproxy.pp
@@ -9,23 +9,26 @@
 # Sample Usage:
 #
 #   class { 'datadog_agent::integrations::haproxy' :
-#     url   => 'http://localhost:8080',
-#     creds => { username => 'admin',
-#                password => 'password',
-#              },
+#     url     => 'http://localhost:8080',
+#     creds   => { username => 'admin',
+#                  password => 'password',
+#                },
+#     options => { collect_aggregates_only => 'False' },
 #   }
 #
 class datadog_agent::integrations::haproxy(
   $creds     = {},
   $url       = "http://${::ipaddress}:8080",
+  $options   = {},
   $instances = undef,
 ) inherits datadog_agent::params {
   include datadog_agent
 
   if !$instances and $url {
     $_instances = [{
-      'creds' => $creds,
-      'url'   => $url,
+      'creds'   => $creds,
+      'url'     => $url,
+      'options' => $options,
     }]
   } elsif !$instances {
     $_instances = []

--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -48,15 +48,21 @@
 #       problematic SSL server certificates. To maintain backwards
 #       compatibility this defaults to false.
 #
-#  skip_event
+#   skip_event
 #       The (optional) skip_event parameter will instruct the check to not
 #       create any event to avoid duplicates with a server side service check.
 #       This defaults to True because this is being deprecated.
 #       (See https://github.com/DataDog/dd-agent/blob/master/checks/network_checks.py#L178-L180)
 #
-#  check_certificate_expiration
-#  days_warning
-#  days_critical
+#   no_proxy
+#       The (optional) no_proxy parameter would bypass any proxy settings enabled
+#       and attempt to reach the the URL directly.
+#       If no proxy is defined at any level, this flag bears no effect.
+#       Defaults to False.
+#
+#   check_certificate_expiration
+#   days_warning
+#   days_critical
 #       The (optional) check_certificate_expiration will instruct the check
 #       to create a service check that checks the expiration of the
 #       ssl certificate. Allow for a warning to occur when x days are
@@ -64,7 +70,7 @@
 #       warning if the certificate is y days from the expiration date.
 #       The SSL certificate will always be validated for this additional
 #       service check regardless of the value of disable_ssl_validation
-# 
+#
 #   headers
 #       The (optional) headers parameter allows you to send extra headers
 #       with the request. This is useful for explicitly specifying the host
@@ -141,6 +147,7 @@ class datadog_agent::integrations::http_check (
   $collect_response_time = true,
   $disable_ssl_validation = false,
   $skip_event = true,
+  $no_proxy  = false,
   $check_certificate_expiration = undef,
   $days_warning = undef,
   $days_critical = undef,
@@ -165,6 +172,7 @@ class datadog_agent::integrations::http_check (
       'collect_response_time'        => $collect_response_time,
       'disable_ssl_validation'       => $disable_ssl_validation,
       'skip_event'                   => $skip_event,
+      'no_proxy'                     => $no_proxy,
       'check_certificate_expiration' => $check_certificate_expiration,
       'days_warning'                 => $days_warning,
       'days_critical'                => $days_critical,

--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -37,6 +37,13 @@
 #       check to create a metric 'network.http.response_time', tagged with
 #       the url, reporting the response time in seconds.
 #
+#   http_response_status_code
+#       The (optional) http_response_status_code parameter will instruct the check
+#       to look for a particular HTTP response status code or a Regex identifying
+#       a set of possible status codes.
+#       The check will report as DOWN if status code returned differs.
+#       This defaults to 1xx, 2xx and 3xx HTTP status code: (1|2|3)\d\d.
+#
 #   collect_response_time
 #       The (optional) collect_response_time parameter will instruct the
 #       check to create a metric 'network.http.response_time', tagged with
@@ -144,6 +151,7 @@ class datadog_agent::integrations::http_check (
   $window    = undef,
   $content_match = undef,
   $include_content = false,
+  $http_response_status_code = undef,
   $collect_response_time = true,
   $disable_ssl_validation = false,
   $skip_event = true,
@@ -169,6 +177,7 @@ class datadog_agent::integrations::http_check (
       'window'                       => $window,
       'content_match'                => $content_match,
       'include_content'              => $include_content,
+      'http_response_status_code'    => $http_response_status_code,
       'collect_response_time'        => $collect_response_time,
       'disable_ssl_validation'       => $disable_ssl_validation,
       'skip_event'                   => $skip_event,

--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -51,7 +51,8 @@
 #  skip_event
 #       The (optional) skip_event parameter will instruct the check to not
 #       create any event to avoid duplicates with a server side service check.
-#       This default to False.
+#       This defaults to True because this is being deprecated.
+#       (See https://github.com/DataDog/dd-agent/blob/master/checks/network_checks.py#L178-L180)
 #
 #  check_certificate_expiration
 #  days_warning
@@ -139,7 +140,7 @@ class datadog_agent::integrations::http_check (
   $include_content = false,
   $collect_response_time = true,
   $disable_ssl_validation = false,
-  $skip_event = undef,
+  $skip_event = true,
   $check_certificate_expiration = undef,
   $days_warning = undef,
   $days_critical = undef,

--- a/manifests/integrations/memcache.pp
+++ b/manifests/integrations/memcache.pp
@@ -19,18 +19,44 @@
 #   url      => 'localhost',
 # }
 #
+#
+# Sample Usage (Instance):
+#  class { 'datadog_agent::integrations::memcache' :
+#    instances => [{
+#      url   => 'localhost',
+#      port  => '11211',
+#      items => false,
+#      slabs => false,
+#    }]
+#  }
+#
 class datadog_agent::integrations::memcache (
   $url                    = 'localhost',
   $port                   = 11211,
   $tags                   = [],
   $items                  = false,
   $slabs                  = false,
+  $instances = undef,
 ) inherits datadog_agent::params {
   include datadog_agent
 
   validate_string($url)
   validate_array($tags)
   validate_integer($port)
+
+  if !$instances and $url {
+    $_instances = [{
+      'url'   => $url,
+      'port'  => $port,
+      'tags'  => $tags,
+      'items' => $items,
+      'slabs' => $slabs,
+    }]
+  } elsif !$instances{
+    $_instances = []
+  } else {
+    $_instances = $instances
+  }
 
   file { "${datadog_agent::params::conf_dir}/mcache.yaml":
     ensure  => file,

--- a/manifests/integrations/mongo.pp
+++ b/manifests/integrations/mongo.pp
@@ -47,9 +47,11 @@
 #        'username'           => 'mongo_username',
 #      },
 #      {
-#        'host' => 'localhost',
-#        'port' => '27018',
-#        'tags' => [],
+#        'host'               => 'localhost',
+#        'port'               => '27018',
+#        'tags'               => [],
+#        'additional_metrics' => [],
+#        'collections'        => [],
 #      },
 #    ]
 #  }

--- a/manifests/integrations/php_fpm.pp
+++ b/manifests/integrations/php_fpm.pp
@@ -21,9 +21,9 @@
 #
 
 class datadog_agent::integrations::php_fpm(
-  $http_host        = undef,
   $status_url       = 'http://localhost/status',
   $ping_url         = 'http://localhost/ping',
+  $http_host        = undef,
   $tags             = [],
   $instances        = undef
 ) inherits datadog_agent::params {

--- a/manifests/integrations/php_fpm.pp
+++ b/manifests/integrations/php_fpm.pp
@@ -21,11 +21,24 @@
 #
 
 class datadog_agent::integrations::php_fpm(
+  $http_host        = undef,
   $status_url       = 'http://localhost/status',
   $ping_url         = 'http://localhost/ping',
-  $tags             = []
+  $tags             = [],
+  $instances        = undef
 ) inherits datadog_agent::params {
   include datadog_agent
+
+  if !$instances {
+    $_instances = [{
+      'http_host' => $http_host,
+      'status_url' => $status_url,
+      'ping_url' => $ping_url,
+      'tags' => $tags,
+    }]
+  } else {
+    $_instances = $instances
+  }
 
   file { "${datadog_agent::params::conf_dir}/php_fpm.yaml":
     ensure  => file,

--- a/manifests/integrations/postfix.pp
+++ b/manifests/integrations/postfix.pp
@@ -1,0 +1,64 @@
+# Class: datadog_agent::integrations::postfix
+#
+# This class will install the necessary configuration for the Postfix integration
+#
+# Parameters:
+#   $url:
+#       url used to connect to the Postfixd instance
+#   $port:
+#   $tags
+#       Optional array of tags
+#
+# Sample Usage:
+#
+# include 'datadog_agent::integrations::postfix'
+#
+# OR
+#
+# class { 'datadog_agent::integrations::postfix':
+#   directory => '/var/spool/postfix-2'
+# }
+#
+#
+# Sample Usage (Instance):
+#  class { 'datadog_agent::integrations::postfix' :
+#    instances => [{
+#      directory => '/var/spool/postfix-2',
+#      queues    => [ 'active', 'deferred' ]
+#    }]
+#  }
+#
+class datadog_agent::integrations::postfix (
+  $directory              = '/var/spool/postfix',
+  $queues                 = [ 'active', 'deferred', 'incoming' ],
+  $tags                   = [],
+  $instances = undef,
+) inherits datadog_agent::params {
+  include datadog_agent
+
+  validate_string($directory)
+  validate_array($queues)
+  validate_array($tags)
+
+  if !$instances and $directory {
+    $_instances = [{
+      'directory'   => $directory,
+      'queues'      => $queues,
+      'tags'        => $tags
+    }]
+  } elsif !$instances{
+    $_instances = []
+  } else {
+    $_instances = $instances
+  }
+
+  file { "${datadog_agent::params::conf_dir}/postfix.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0600',
+    content => template('datadog_agent/agent-conf.d/postfix.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/manifests/integrations/rabbitmq.pp
+++ b/manifests/integrations/rabbitmq.pp
@@ -11,6 +11,30 @@
 #       If your service uses basic authentication, you can optionally
 #       specify a username and password that will be used in the check.
 #       (it's set to guest/guest by RabbitMQ on setup)
+#   $tag_families
+#       Tag queues "families" based on regex match
+#   $ssl_verify
+#       Skip verification of the RabbitMQ management web endpoint 
+#       SSL certificate 
+#   $nodes
+#   $nodes_regexes
+#       Specify the nodes to collect metrics on (up to 100 nodes).
+#       If you have less than 100 nodes, metrics will be collected on all nodes
+#       by default.
+#   $queues
+#   $queues_regexes
+#       Specify the queues to collect metrics on (up to 200 queues).
+#
+#       If you have less than 200 queues, metrics will be collected on all queues
+#       by default.
+#
+#       If vhosts are set, set queue names as `vhost_name/queue_name`
+#
+#       If `tag families` are enabled, the first capture group in the regex will
+#       be used as the queue_family tag
+#   $vhosts
+#       List of vhosts to monitor with service checks. By default, a list of all
+#       vhosts is fetched and each one will be checked using the aliveness API.
 #
 # Sample Usage:
 #
@@ -22,12 +46,28 @@
 #
 
 class datadog_agent::integrations::rabbitmq (
-  $url       = undef,
-  $username  = undef,
-  $password  = undef,
-  $queues    = undef,
-  $vhosts    = undef,
+  $url            = undef,
+  $username       = 'guest',
+  $password       = 'guest',
+  $ssl_verify     = true,
+  $tag_families   = false,
+  $nodes          = [],
+  $nodes_regexes  = [],
+  $queues         = [],
+  $queues_regexes = [],
+  $vhosts         = [],
 ) inherits datadog_agent::params {
+
+  validate_string($url)
+  validate_string($username)
+  validate_string($password)
+  validate_bool($ssl_verify)
+  validate_bool($tag_families)
+  validate_array($nodes)
+  validate_array($nodes_regexes)
+  validate_array($queues)
+  validate_array($queues_regexes)
+  validate_array($vhosts)
   include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/rabbitmq.yaml":
@@ -37,6 +77,6 @@ class datadog_agent::integrations::rabbitmq (
     mode    => '0600',
     content => template('datadog_agent/agent-conf.d/rabbitmq.yaml.erb'),
     require => Package[$datadog_agent::params::package_name],
-    notify  => Service[$datadog_agent::params::service_name]
+    notify  => Service[$datadog_agent::params::service_name],
   }
 }

--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -17,6 +17,8 @@
 #       Optional array of tags
 #   $keys
 #       Optional array of keys to check length
+#   $command_stats
+#       Collect INFO COMMANDSTATS output as metrics
 #
 # Sample Usage:
 #
@@ -34,12 +36,15 @@ class datadog_agent::integrations::redis(
   $tags = [],
   $keys = [],
   $warn_on_missing_keys = true,
+  $command_stats = false,
+
 ) inherits datadog_agent::params {
   include datadog_agent
 
   validate_array($tags)
   validate_array($keys)
   validate_bool($warn_on_missing_keys)
+  validate_bool($command_stats)
 
   if $ports == undef {
     $_ports = [ $port ]

--- a/manifests/integrations/tcp_check.pp
+++ b/manifests/integrations/tcp_check.pp
@@ -1,0 +1,129 @@
+# Class: datadog_agent::integrations::tcp_check
+#
+# This class will install the necessary config to hook the tcp_check in the agent
+#
+# Parameters:
+#   name
+#       (Required) - Name of the service. 
+#        This will be included as a tag: instance:<name>.
+#
+#   host
+#       (Required) - Host to be checked. 
+#        This will be included as a tag: url:<host>:<port>.
+#
+#   port
+#       (Required) - Port to be checked. 
+#        This will be included as a tag: url:<host>:<port>.
+#
+#   timeout
+#       (Optional) - Timeout for the check. Defaults to 10 seconds.
+#
+#   threshold
+#       (Optional) - Used in conjunction with window. An alert will 
+#        trigger if the check fails <threshold> times in <window> attempts.
+#
+#   window
+#       (Optional) - Refer to threshold.
+#
+#   collect_response_time
+#       (Optional) - Defaults to false. If this is not set to true, no 
+#       response time metric will be collected. If it is set to true, the 
+#       metric returned is network.tcp.response_time. 
+#
+#   skip_event
+#        The (optional) skip_event parameter will instruct the check to not
+#        create any event to avoid duplicates with a server side service check.
+#        This default to False.
+#
+#   tags
+#       The (optional) tags to add to the check instance.
+#
+# Sample Usage:
+#
+# Add a class for each check instance:
+#
+# class { 'datadog_agent::integrations::tcp_check':
+#   name  => 'localhost-ftp',
+#   host       => 'ftp.example.com',
+#   port       => '21',
+# }
+#
+# class { 'datadog_agent::integrations::tcp_check':
+#   name  => 'localhost-ssh',
+#   host       => '127.0.0.1',
+#   port       => '22',
+#   threshold             => 1,
+#   window                => 1,
+#   tags     => ['production', 'ssh access'],
+# }
+#
+# class { 'datadog_agent::integrations::tcp_check':
+#   name  => 'localhost-web-response',
+#   host       => '127.0.0.1',
+#   port       => '80',
+#   timeout    => '8',
+#   threshold             => 1,
+#   window                => 1,
+#   collect_response_time => 1,
+#   skip_event            => 1,
+#   tags     => ['production', 'webserver response time'],
+# }
+#
+# Add multiple instances in one class declaration:
+#
+#  class { 'datadog_agent::integrations::tcp_check':
+#        instances => [{
+#          'name'  => 'www.example.com-http',
+#          'host'  => 'www.example.com',
+#          'port'       => '80',
+#        },
+#        {
+#          'name'  => 'www.example.com-https',
+#          'host'  => 'www.example.com',
+#          'port'       => '443',
+#        }]
+#     }
+
+
+class datadog_agent::integrations::tcp_check (
+  $check_name      = undef,
+  $host      = undef,
+  $port      = undef,
+  $timeout   = 10,
+  $threshold = undef,
+  $window    = undef,
+  $collect_response_time = undef,
+  $skip_event = undef,
+  $tags      = [],
+  $instances  = undef,
+) inherits datadog_agent::params {
+  include datadog_agent
+
+  if !$instances and $host {
+    $_instances = [{
+      'check_name'                   => $check_name,
+      'host'                         => $host,
+      'port'                         => $port,
+      'timeout'                      => $timeout,
+      'threshold'                    => $threshold,
+      'window'                       => $window,
+      'collect_response_time'        => $collect_response_time,
+      'skip_event'                   => $skip_event,
+      'tags'                         => $tags,
+    }]
+  } elsif !$instances{
+    $_instances = []
+  } else {
+    $_instances = $instances
+  }
+
+  file { "${datadog_agent::params::conf_dir}/tcp_check.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0600',
+    content => template('datadog_agent/agent-conf.d/tcp_check.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/manifests/integrations/twemproxy.pp
+++ b/manifests/integrations/twemproxy.pp
@@ -1,0 +1,53 @@
+# Class: datadog_agent::integrations::twemproxy
+#
+# This class will install the necessary configuration for the twemproxy aka nutcracker integration
+#
+# Parameters:
+#   $host:
+#       The host twemproxy is running on. Defaults to '127.0.0.1'
+#   $port
+#       The twemproxy password for the datadog user. Defaults to 22222
+#
+# Sample Usage:
+#
+#  class { 'datadog_agent::integrations::twemproxy' :
+#    instances => [
+#      {
+#        'host' => 'localhost',
+#        'port' => '22222',
+#      },
+#      {
+#        'host' => 'localhost',
+#        'port' => '22223',
+#      },
+#    ]
+#  }
+#
+class datadog_agent::integrations::twemproxy(
+  $host = 'localhost',
+  $port = '22222',
+  $instances = undef,
+) inherits datadog_agent::params {
+  include datadog_agent
+
+  if !$instances and $host {
+    $_instances = [{
+      'host' => $host,
+      'port' => $port,
+    }]
+  } elsif !$instances{
+    $_instances = []
+  } else {
+    $_instances = $instances
+  }
+
+  file { "${datadog_agent::params::conf_dir}/twemproxy.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0600',
+    content => template('datadog_agent/agent-conf.d/twemproxy.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/manifests/integrations/zk.pp
+++ b/manifests/integrations/zk.pp
@@ -6,7 +6,7 @@
 #   $host:
 #       The host zk is running on. Defaults to '127.0.0.1'
 #   $port
-#       The zk password for the datadog user. Defaults to 27017
+#       The port zk is running on. Defaults to 2181
 #   $tags
 #       Optional array of tags
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class datadog_agent::params {
   $package_name   = 'datadog-agent'
   $service_name   = 'datadog-agent'
   $dogapi_version = 'installed'
+  $conf_dir_purge = false
 
   case $::operatingsystem {
     'Ubuntu','Debian' : {

--- a/manifests/tag.pp
+++ b/manifests/tag.pp
@@ -1,28 +1,28 @@
 # Allow custom tags via a define
 define datadog_agent::tag(
-  $tag = $name,
+  $tag_name = $name,
   $lookup_fact = false,
 ){
 
   if $lookup_fact{
-    $value = getvar($tag)
+    $value = getvar($tag_name)
 
     if is_array($value){
-      $tags = prefix($value, "${tag}:")
+      $tags = prefix($value, "${tag_name}:")
       datadog_agent::tag{$tags: }
     } else {
       if $value {
-        concat::fragment{ "datadog tag ${tag}:${value}":
+        concat::fragment{ "datadog tag ${tag_name}:${value}":
           target  => '/etc/dd-agent/datadog.conf',
-          content => "${tag}:${value}, ",
+          content => "${tag_name}:${value}, ",
           order   => '03',
         }
       }
     }
   } else {
-    concat::fragment{ "datadog tag ${tag}":
+    concat::fragment{ "datadog tag ${tag_name}":
       target  => '/etc/dd-agent/datadog.conf',
-      content => "${tag}, ",
+      content => "${tag_name}, ",
       order   => '03',
     }
   }

--- a/manifests/tag.pp
+++ b/manifests/tag.pp
@@ -1,0 +1,30 @@
+# Allow custom tags via a define
+define datadog_agent::tag(
+  $tag = $name,
+  $lookup_fact = false,
+){
+
+  if $lookup_fact{
+    $value = getvar($tag)
+
+    if is_array($value){
+      $tags = prefix($value, "${tag}:")
+      datadog_agent::tag{$tags: }
+    } else {
+      if $value {
+        concat::fragment{ "datadog tag ${tag}:${value}":
+          target  => '/etc/dd-agent/datadog.conf',
+          content => "${tag}:${value}, ",
+          order   => '03',
+        }
+      }
+    }
+  } else {
+    concat::fragment{ "datadog tag ${tag}":
+      target  => '/etc/dd-agent/datadog.conf',
+      content => "${tag}, ",
+      order   => '03',
+    }
+  }
+
+}

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -15,7 +15,10 @@
 class datadog_agent::ubuntu(
   $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
   $agent_version = 'latest',
-  $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52']
+  $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52'],
+  $location = 'https://apt.datadoghq.com',
+  $release = 'stable',
+  $repos = 'main',
 ) {
 
   ensure_packages(['apt-transport-https'])
@@ -31,9 +34,9 @@ class datadog_agent::ubuntu(
   }
 
   file { '/etc/apt/sources.list.d/datadog.list':
-    source  => 'puppet:///modules/datadog_agent/datadog.list',
     owner   => 'root',
     group   => 'root',
+    content => template('datadog_agent/datadog.list.erb'),
     notify  => Exec['datadog_apt-get_update'],
     require => Package['apt-transport-https'],
   }

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -13,9 +13,9 @@
 #
 
 class datadog_agent::ubuntu(
-  $apt_key = '382E94DE',
+  $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
   $agent_version = 'latest',
-  $other_keys = ['C7A7DA52']
+  $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52']
 ) {
 
   ensure_packages(['apt-transport-https'])

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-datadog_agent",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": "James Turnbull (<james@lovedthanlost.net>) and Rob Terhaar (<rob@atlanticdynamic>) for Datadog Inc.",
   "summary": "Install the Datadog monitoring agent and report Puppet runs to Datadog",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -73,6 +73,10 @@
       "version_requirement": ">=0.2.0 <1.0.0"
     },
     {
+      "name": "puppetlabs/concat",
+      "version_requirement": "2.2.0"
+    },
+    {
       "name": "lwf/remote_file",
       "version_requirement": ">=1.1.3"
     }

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "1.10.0",
   "author": "James Turnbull (<james@lovedthanlost.net>) and Rob Terhaar (<rob@atlanticdynamic>) for Datadog Inc.",
   "summary": "Install the Datadog monitoring agent and report Puppet runs to Datadog",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "source": "git://github.com/DataDog/puppet-datadog-agent.git",
   "project_page": "https://github.com/DataDog/puppet-datadog-agent",
   "issues_url": "https://github.com/DataDog/puppet-datadog-agent/issues",
@@ -66,7 +66,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.6.0"
+      "version_requirement": ">=4.6.0 <5.0.0"
     },
     {
       "name": "puppetlabs/ruby",
@@ -78,7 +78,7 @@
     },
     {
       "name": "lwf/remote_file",
-      "version_requirement": ">=1.1.3"
+      "version_requirement": ">=1.1.3 <2.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-datadog_agent",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": "James Turnbull (<james@lovedthanlost.net>) and Rob Terhaar (<rob@atlanticdynamic>) for Datadog Inc.",
   "summary": "Install the Datadog monitoring agent and report Puppet runs to Datadog",
   "license": "Apache License, Version 2.0",

--- a/spec/classes/datadog_agent_integrations_ceph_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ceph_spec.rb
@@ -28,4 +28,24 @@ describe 'datadog_agent::integrations::ceph' do
     it { should contain_file(sudo_conf_file).with_content(/^dd-agent\sALL=.*NOPASSWD:\/usr\/bin\/ceph$/) }
   end
 
+  context 'with specified tag' do
+    let(:params) {{
+      tags: ['name:my_ceph_cluster'],
+    }}
+    it { should contain_file(conf_file).with_content(/tags:\s+- name:my_ceph_cluster\s*?[^-]/m) }
+    it { should contain_file(conf_file).with_content(/^\s*ceph_cmd:\s*\/usr\/bin\/ceph\s*?[^-]/m) }
+    it { should contain_file(conf_file).with_content(/^\s*use_sudo:\sTrue$/) }
+    it { should contain_file(sudo_conf_file).with_content(/^dd-agent\sALL=.*NOPASSWD:\/usr\/bin\/ceph$/) }
+  end
+
+  context 'with specified ceph_cmd' do
+    let(:params) {{
+      ceph_cmd: '/usr/local/myceph',
+    }}
+    it { should contain_file(conf_file).with_content(/tags:\s+- name:ceph_cluster\s*?[^-]/m) }
+    it { should contain_file(conf_file).with_content(/^\s*ceph_cmd:\s*\/usr\/local\/myceph\s*?[^-]/m) }
+    it { should contain_file(conf_file).with_content(/^\s*use_sudo:\sTrue$/) }
+    it { should contain_file(sudo_conf_file).with_content(/^dd-agent\sALL=.*NOPASSWD:\/usr\/bin\/ceph$/) }
+  end
+
 end

--- a/spec/classes/datadog_agent_integrations_ceph_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ceph_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::ceph' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/ceph.yaml" }
+  let(:sudo_conf_file) { '/etc/sudoers.d/datadog_ceph' }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(/tags:\s+- name:ceph_cluster\s*?[^-]/m) }
+    it { should contain_file(conf_file).with_content(/^\s*ceph_cmd:\s*\/usr\/bin\/ceph\s*?[^-]/m) }
+    it { should contain_file(conf_file).with_content(/^\s*use_sudo:\sTrue$/) }
+    it { should contain_file(sudo_conf_file).with_content(/^dd-agent\sALL=.*NOPASSWD:\/usr\/bin\/ceph$/) }
+  end
+
+end

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -33,7 +33,8 @@ describe 'datadog_agent::integrations::elasticsearch' do
     it { should_not contain_file(conf_file).with_content(%r{      ssl_key}) }
     it { should_not contain_file(conf_file).with_content(%r{      tags:}) }
   end
-context 'with parameters set' do
+
+  context 'with parameters set' do
     let(:params) {{
       password:           'password',
       pending_task_stats: false,
@@ -54,4 +55,59 @@ context 'with parameters set' do
     it { should contain_file(conf_file).with_content(%r{        - tag1:key1}) }
   end
 
+  context 'with multiple instances set' do
+    let(:params) {
+      {
+        instances: [
+          {
+            'cluster_stats'      => true,
+            'password'           => 'password',
+            'pending_task_stats' => false,
+            'pshard_stats'       => false,
+            'url'                => 'https://foo:4242',
+            'username'           => 'username',
+            'ssl_verify'         => true,
+            'ssl_cert'           => '/etc/ssl/certs/client.pem',
+            'ssl_key'            => '/etc/ssl/private/client.key',
+            'tags'               => ['tag1:key1'],
+          },
+          {
+            'cluster_stats'      => true,
+            'password'           => 'password_2',
+            'pending_task_stats' => true,
+            'pshard_stats'       => false,
+            'url'                => 'https://bar:2424',
+            'username'           => 'username_2',
+            'ssl_verify'         => false,
+            'ssl_cert'           => '/etc/ssl/certs/client.pem',
+            'ssl_key'            => '/etc/ssl/private/client.key',
+            'tags'               => ['tag2:key2'],
+          }
+        ]
+      }
+    }
+    it { should contain_file(conf_file).with_content(%r{instances:}) }
+    it { should contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
+    it { should contain_file(conf_file).with_content(%r{      cluster_stats: true}) }
+    it { should contain_file(conf_file).with_content(%r{      pending_task_stats: false}) }
+    it { should contain_file(conf_file).with_content(%r{      username: username}) }
+    it { should contain_file(conf_file).with_content(%r{      password: password}) }
+    it { should contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_verify: true}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
+    it { should contain_file(conf_file).with_content(%r{      tags:}) }
+    it { should contain_file(conf_file).with_content(%r{        - tag1:key1}) }
+    it { should contain_file(conf_file).with_content(%r{    - url: https://bar:2424}) }
+    it { should contain_file(conf_file).with_content(%r{      cluster_stats: true}) }
+    it { should contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
+    it { should contain_file(conf_file).with_content(%r{      username: username_2}) }
+    it { should contain_file(conf_file).with_content(%r{      password: password_2}) }
+    it { should contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_verify: false}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
+    it { should contain_file(conf_file).with_content(%r{      tags:}) }
+    it { should contain_file(conf_file).with_content(%r{        - tag2:key2}) }
+  end
 end

--- a/spec/classes/datadog_agent_integrations_haproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_haproxy_spec.rb
@@ -55,30 +55,47 @@ describe 'datadog_agent::integrations::haproxy' do
     end
   end
 
+  context 'with options set' do
+    let(:params) {{
+      options: {
+        'optionk' => 'optionv',
+      },
+    }}
+    it { should contain_file(conf_file).with_content(%r{optionk: optionv}) }
+  end
+
   context 'with instances set' do
     let(:params) {{
       instances: [
         {
-          'url'   => 'http://foo.bar:8421',
-          'creds' => {
+          'url'     => 'http://foo.bar:8421',
+          'creds'   => {
             'username' => 'foo',
             'password' => 'bar',
-          }
+          },
+          'options' => {
+            'optionk1' => 'optionv1',
+          },
         },
         {
-          'url'   => 'http://shoe.baz:1248',
-          'creds' => {
+          'url'     => 'http://shoe.baz:1248',
+          'creds'   => {
             'username' => 'shoe',
             'password' => 'baz',
-          }
+          },
+          'options' => {
+            'optionk2' => 'optionv2',
+          },
         },
       ]
     }}
     it { should contain_file(conf_file).with_content(%r{url: http://foo.bar:8421}) }
     it { should contain_file(conf_file).with_content(%r{username: foo}) }
     it { should contain_file(conf_file).with_content(%r{password: bar}) }
+    it { should contain_file(conf_file).with_content(%r{optionk1: optionv1}) }
     it { should contain_file(conf_file).with_content(%r{url: http://shoe.baz:1248}) }
     it { should contain_file(conf_file).with_content(%r{username: shoe}) }
     it { should contain_file(conf_file).with_content(%r{password: baz}) }
+    it { should contain_file(conf_file).with_content(%r{optionk2: optionv2}) }
   end
 end

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -31,6 +31,7 @@ describe 'datadog_agent::integrations::http_check' do
     it { should contain_file(conf_file).without_content(%r{content_match: }) }
     it { should contain_file(conf_file).without_content(%r{include_content: true}) }
     it { should contain_file(conf_file).without_content(%r{collect_response_time: true}) }
+    it { should contain_file(conf_file).without_content(%r{http_response_status_code: }) }
     it { should contain_file(conf_file).without_content(%r{disable_ssl_validation: false}) }
     it { should contain_file(conf_file).without_content(%r{skip_event: }) }
     it { should contain_file(conf_file).without_content(%r{no_proxy: }) }
@@ -55,6 +56,7 @@ describe 'datadog_agent::integrations::http_check' do
       collect_response_time: false,
       disable_ssl_validation: true,
       skip_event: true,
+      http_response_status_code: '503',
       no_proxy: true,
       check_certificate_expiration: true,
       days_warning: 14,
@@ -73,6 +75,7 @@ describe 'datadog_agent::integrations::http_check' do
     it { should contain_file(conf_file).without_content(%r{collect_response_time: true}) }
     it { should contain_file(conf_file).with_content(%r{disable_ssl_validation: true}) }
     it { should contain_file(conf_file).with_content(%r{skip_event: true}) }
+    it { should contain_file(conf_file).with_content(%r{http_response_status_code: 503}) }
     it { should contain_file(conf_file).with_content(%r{no_proxy: true}) }
     it { should contain_file(conf_file).with_content(%r{check_certificate_expiration: true}) }
     it { should contain_file(conf_file).with_content(%r{days_warning: 14}) }

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -33,9 +33,10 @@ describe 'datadog_agent::integrations::http_check' do
     it { should contain_file(conf_file).without_content(%r{collect_response_time: true}) }
     it { should contain_file(conf_file).without_content(%r{disable_ssl_validation: false}) }
     it { should contain_file(conf_file).without_content(%r{skip_event: }) }
+    it { should contain_file(conf_file).without_content(%r{no_proxy: }) }
     it { should contain_file(conf_file).without_content(%r{check_certificate_expiration: }) }
     it { should contain_file(conf_file).without_content(%r{days_warning: }) }
-    it { should contain_file(conf_file).without_content(%r{days_critical: }) }    
+    it { should contain_file(conf_file).without_content(%r{days_critical: }) }
     it { should contain_file(conf_file).without_content(%r{headers: }) }
     it { should contain_file(conf_file).without_content(%r{tags: }) }
   end
@@ -54,6 +55,7 @@ describe 'datadog_agent::integrations::http_check' do
       collect_response_time: false,
       disable_ssl_validation: true,
       skip_event: true,
+      no_proxy: true,
       check_certificate_expiration: true,
       days_warning: 14,
       days_critical: 7,
@@ -71,6 +73,7 @@ describe 'datadog_agent::integrations::http_check' do
     it { should contain_file(conf_file).without_content(%r{collect_response_time: true}) }
     it { should contain_file(conf_file).with_content(%r{disable_ssl_validation: true}) }
     it { should contain_file(conf_file).with_content(%r{skip_event: true}) }
+    it { should contain_file(conf_file).with_content(%r{no_proxy: true}) }
     it { should contain_file(conf_file).with_content(%r{check_certificate_expiration: true}) }
     it { should contain_file(conf_file).with_content(%r{days_warning: 14}) }
     it { should contain_file(conf_file).with_content(%r{days_critical: 7}) }

--- a/spec/classes/datadog_agent_integrations_memcache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_memcache_spec.rb
@@ -17,6 +17,7 @@ describe 'datadog_agent::integrations::memcache' do
     group: dd_group,
     mode: '0600',
   )}
+
   it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
   it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
 
@@ -62,7 +63,6 @@ describe 'datadog_agent::integrations::memcache' do
       let(:params) {{
         tags: [ 'foo', '', 'baz' ]
       }}
-
       it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
     end
 
@@ -81,5 +81,41 @@ describe 'datadog_agent::integrations::memcache' do
 
       skip("doubly undefined behavior")
     end
+  end
+
+  context 'with multiple instances set' do
+    let(:params) {
+      {
+        instances: [
+          {
+            'url'   => 'localhost',
+            'port'  => '11211',
+            'items' => true,
+            'slabs' => true,
+            'tags'  => ['tag1:value1'],
+          },
+          {
+            'url'   => 'foo.bar',
+            'port'  => '11212',
+            'items' => false,
+            'slabs' => false,
+            'tags'  => ['tag2:value2'],
+          }
+        ]
+      }
+    }
+    it { should contain_file(conf_file).with_content(%r{instances:}) }
+    it { should contain_file(conf_file).with_content(%r{  - url: localhost}) }
+    it { should contain_file(conf_file).with_content(%r{    port: 11211}) }
+    it { should contain_file(conf_file).with_content(%r{    items: true}) }
+    it { should contain_file(conf_file).with_content(%r{    slabs: true}) }
+    it { should contain_file(conf_file).with_content(%r{    tags:}) }
+    it { should contain_file(conf_file).with_content(%r{      - tag1:value1}) }
+    it { should contain_file(conf_file).with_content(%r{  - url: foo.bar}) }
+    it { should contain_file(conf_file).with_content(%r{    port: 11212}) }
+    it { should contain_file(conf_file).with_content(%r{    items: false}) }
+    it { should contain_file(conf_file).with_content(%r{    slabs: false}) }
+    it { should contain_file(conf_file).with_content(%r{    tags:}) }
+    it { should contain_file(conf_file).with_content(%r{      - tag2:value2}) }
   end
 end

--- a/spec/classes/datadog_agent_integrations_mongo_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mongo_spec.rb
@@ -59,6 +59,59 @@ describe 'datadog_agent::integrations::mongo' do
     it { should contain_file(conf_file).with_content(%r{server:.*127.0.0.1.*server:.*127.0.0.2}m) }
   end
 
+  context 'with custom collections one mongos' do
+    let(:params) {{
+      servers: [
+        {
+          'host' => '127.0.0.1',
+          'port' => '12345',
+          'tags' => %w{ foo bar baz },
+          'collections' => %w{ collection_1 collection_2 },
+        },
+        {
+          'host' => '127.0.0.2',
+          'port' => '45678',
+          'tags' => %w{baz bat},
+          'collections' => %w{ collection_1 collection_2 },
+        }
+      ]
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz\s+collections:\s+- collection_1\s+- collection_2}) }
+    it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.2:45678/\s+tags:\s+- baz\s+- bat\s+collections:\s+- collection_1\s+- collection_2}) }
+
+  end
+
+  context 'with custom collections multiple mongo' do
+    let(:params) {{
+      servers: [
+        {
+          'host' => '127.0.0.1',
+          'port' => '12345',
+          'tags' => %w{ foo bar baz },
+          'collections' => %w{ collection_1 collection_2 },
+        }
+      ]
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz\s+collections:\s+- collection_1\s+- collection_2}) }
+  end
+
+  context 'with additional metrics' do
+    let(:params) {{
+      servers: [
+        {
+          'host' => '127.0.0.1',
+          'port' => '12345',
+          'tags' => %w{ foo bar baz },
+          'additional_metrics' => %w{ top },
+        }
+      ]
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz\s+additional_metrics:\s+- top}) }
+  end
+
   context 'without tags' do
     let(:params) {{
       servers: [

--- a/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
+++ b/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
@@ -33,4 +33,34 @@ describe 'datadog_agent::integrations::php_fpm' do
     it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/fpm_status/) }
     it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/fpm_ping/) }
   end
+
+  context 'with http_host set' do
+    let(:params) {{
+      status_url: 'http://localhost/fpm_status',
+      ping_url: 'http://localhost/fpm_ping',
+      http_host: 'php_fpm_server',
+    }}
+    it { should contain_file(conf_file).with_content(/http_host: php_fpm_server/) }
+    it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/fpm_status/) }
+    it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/fpm_ping/) }
+  end
+
+  context 'with instances set' do
+    let(:params) {{
+      instances: [
+        {
+          'status_url'   => 'http://localhost/a/fpm_status',
+          'ping_url'   => 'http://localhost/a/fpm_ping',
+        },
+        {
+          'status_url'   => 'http://localhost/b/fpm_status',
+          'ping_url'   => 'http://localhost/b/fpm_ping',
+        },
+      ]
+    }}
+    it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/a\/fpm_status/) }
+    it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/a\/fpm_ping/) }
+    it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/b\/fpm_status/) }
+    it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/b\/fpm_ping/) }
+  end
 end

--- a/spec/classes/datadog_agent_integrations_postfix_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postfix_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::postfix' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/postfix.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{  - directory: /var/spool/postfix}) }
+    it { should contain_file(conf_file).with_content(%r{    queues:}) }
+    it { should contain_file(conf_file).with_content(%r{      - active}) }
+    it { should contain_file(conf_file).with_content(%r{      - deferred}) }
+    it { should contain_file(conf_file).with_content(%r{      - incoming}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      directory: '/var/spool/foobaz',
+      queues:    ['foobar'],
+      tags:      ['tag1:value1'],
+    }}
+    it { should contain_file(conf_file).with_content(%r{  - directory: /var/spool/foobaz}) }
+    it { should contain_file(conf_file).with_content(%r{    queues:}) }
+    it { should contain_file(conf_file).with_content(%r{      - foobar}) }
+    it { should contain_file(conf_file).with_content(%r{    tags:}) }
+    it { should contain_file(conf_file).with_content(%r{      - tag1:value1}) }
+  end
+
+  context 'with multiple instances set' do
+    let(:params) {
+      {
+        instances: [
+          {
+            'directory' => '/var/spool/postfix-2',
+            'queues'    => 'active',
+            'tags'      => ['tag2:value2'],
+          },
+          {
+            'directory' => '/var/spool/postfix-3',
+            'queues'    => 'incoming',
+            'tags'      => ['tag3:value3'],
+          },
+          
+        ]
+      }
+    }
+    it { should contain_file(conf_file).with_content(%r{instances:}) }
+    it { should contain_file(conf_file).with_content(%r{  - directory: /var/spool/postfix-2}) }
+    it { should contain_file(conf_file).with_content(%r{    queues:}) }
+    it { should contain_file(conf_file).with_content(%r{      - active}) }
+    it { should contain_file(conf_file).with_content(%r{    tags:}) }
+    it { should contain_file(conf_file).with_content(%r{      - tag2:value2}) }
+    it { should contain_file(conf_file).with_content(%r{  - directory: /var/spool/postfix-3}) }
+    it { should contain_file(conf_file).with_content(%r{    queues:}) }
+    it { should contain_file(conf_file).with_content(%r{      - incoming}) }
+    it { should contain_file(conf_file).with_content(%r{    tags:}) }
+    it { should contain_file(conf_file).with_content(%r{      - tag3:value3}) }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
+++ b/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
@@ -21,11 +21,16 @@ describe 'datadog_agent::integrations::rabbitmq' do
   it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
 
   context 'with default parameters' do
-    it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url: }) }
-    it { should contain_file(conf_file).without_content(%r{rabbitmq_user: }) }
-    it { should contain_file(conf_file).without_content(%r{rabbitmq_pass: }) }
-    it { should contain_file(conf_file).without_content(%r{queues: }) }
-    it { should contain_file(conf_file).without_content(%r{vhosts: }) }
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url:}) }
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_user: guest}) }
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_pass: guest}) }
+    it { should contain_file(conf_file).with_content(%r{ssl_verify: true}) }
+    it { should contain_file(conf_file).with_content(%r{tag_families: false}) }
+    it { should contain_file(conf_file).without_content(%r{nodes:}) }
+    it { should contain_file(conf_file).without_content(%r{nodes_regexes:}) }
+    it { should contain_file(conf_file).without_content(%r{queues:}) }
+    it { should contain_file(conf_file).without_content(%r{queues_regexes:}) }
+    it { should contain_file(conf_file).without_content(%r{vhosts:}) }
   end
 
   context 'with parameters set' do
@@ -33,13 +38,23 @@ describe 'datadog_agent::integrations::rabbitmq' do
       url: 'http://rabbit1:15672/',
       username: 'foo',
       password: 'bar',
+      ssl_verify: false,
+      tag_families: true,
+      nodes: %w{ node1 node2 node3 },
+      nodes_regexes: %w{ ^regex1 regex2$ regex3* },
       queues: %w{ queue1 queue2 queue3 },
+      queues_regexes: %w{ ^regex4 regex5$ regex6* },
       vhosts: %w{ vhost1 vhost2 vhost3 },
     }}
     it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url: http://rabbit1:15672/}) }
     it { should contain_file(conf_file).with_content(%r{rabbitmq_user: foo}) }
     it { should contain_file(conf_file).with_content(%r{rabbitmq_pass: bar}) }
+    it { should contain_file(conf_file).with_content(%r{ssl_verify: false}) }
+    it { should contain_file(conf_file).with_content(%r{tag_families: true}) }
+    it { should contain_file(conf_file).with_content(%r{nodes:\s+- node1\s+- node2\s+- node3}) }
+    it { should contain_file(conf_file).with_content(%r{nodes_regexes:\s+- \^regex1\s+- regex2\$\s+- regex3\*}) }
     it { should contain_file(conf_file).with_content(%r{queues:\s+- queue1\s+- queue2\s+- queue3}) }
+    it { should contain_file(conf_file).with_content(%r{queues_regexes:\s+- \^regex4\s+- regex5\$\s+- regex6\*}) }
     it { should contain_file(conf_file).with_content(%r{vhosts:\s+- vhost1\s+- vhost2\s+- vhost3}) }
   end
 end

--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -28,6 +28,7 @@ describe 'datadog_agent::integrations::redis' do
     it { should contain_file(conf_file).without_content(%r{tags:}) }
     it { should contain_file(conf_file).without_content(%r{\bkeys:}) }
     it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: true}) }
+    it { should contain_file(conf_file).with_content(%r{command_stats: false}) }
   end
 
   context 'with parameters set' do
@@ -39,6 +40,7 @@ describe 'datadog_agent::integrations::redis' do
       tags: %w{foo bar},
       keys: %w{baz bat},
       warn_on_missing_keys: false,
+      command_stats: true,
     }}
     it { should contain_file(conf_file).with_content(%r{host: redis1}) }
     it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
@@ -47,6 +49,7 @@ describe 'datadog_agent::integrations::redis' do
     it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
     it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
     it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
+    it { should contain_file(conf_file).with_content(%r{command_stats: true}) }
   end
 
 end

--- a/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::tcp_check' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/tcp_check.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).without_content(%r{name: }) }
+    it { should contain_file(conf_file).without_content(%r{host: }) }
+    it { should contain_file(conf_file).without_content(%r{port: }) }
+    it { should contain_file(conf_file).without_content(%r{timeout: 1}) }
+    it { should contain_file(conf_file).without_content(%{threshold: }) }
+    it { should contain_file(conf_file).without_content(%r{window: }) }
+    it { should contain_file(conf_file).without_content(%r{collect_response_time: }) }
+    it { should contain_file(conf_file).without_content(%r{skip_event: }) }
+    it { should contain_file(conf_file).without_content(%r{tags: }) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      check_name: 'foo.bar.baz',
+      host: 'foo.bar.baz',
+      port: '80',
+      timeout: 123,
+      threshold: 456,
+      window: 789,
+      collect_response_time: true,
+      skip_event: true,
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{name: foo.bar.baz}) }
+    it { should contain_file(conf_file).with_content(%r{host: foo.bar.baz}) }
+    it { should contain_file(conf_file).with_content(%r{port: 80}) }
+    it { should contain_file(conf_file).with_content(%r{timeout: 123}) }
+    it { should contain_file(conf_file).with_content(%r{threshold: 456}) }
+    it { should contain_file(conf_file).with_content(%r{window: 789}) }
+    it { should contain_file(conf_file).with_content(%r{collect_response_time: true}) }
+    it { should contain_file(conf_file).with_content(%r{skip_event: true}) }
+  end
+
+  context 'with tags parameter array' do
+    let(:params) {{
+      check_name: 'foo.bar.baz',
+      host: 'foo.bar.baz',
+      port: '80',
+      tags: [ 'foo', 'bar', 'baz' ],
+    }}
+    it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+  end
+
+  context 'with tags parameter empty values' do
+    context 'mixed in with other tags' do
+      let(:params) {{
+        check_name: 'foo.bar.baz',
+        host: 'foo.bar.baz',
+        port: '80',
+        tags: [ 'foo', '', 'baz' ]
+      }}
+
+      it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+    end
+
+    context 'single element array of an empty string' do
+      let(:params) {{
+        tags: [''],
+      }}
+
+      skip("undefined behavior")
+    end
+
+    context 'single value empty string' do
+      let(:params) {{
+        tags: '',
+      }}
+
+      skip("doubly undefined behavior")
+    end
+  end
+
+end

--- a/spec/classes/datadog_agent_integrations_twemproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_twemproxy_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::twemproxy' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/twemproxy.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{host: localhost}) }
+    it { should contain_file(conf_file).with_content(%r{port: 22222}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      instances: [
+        {
+          'host' => 'twemproxy1',
+          'port' => '1234',
+        },
+        {
+          'host' => 'twemproxy2',
+          'port' => '4567',
+        }
+      ]
+    }}
+    it { should contain_file(conf_file).with_content(%r{host: twemproxy1}) }
+    it { should contain_file(conf_file).with_content(%r{port: 1234}) }
+    it { should contain_file(conf_file).with_content(%r{host: twemproxy2}) }
+    it { should contain_file(conf_file).with_content(%r{port: 4567}) }
+  end
+end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -568,6 +568,9 @@ describe 'datadog_agent' do
                 it { should contain_concat__fragment('datadog apm footer').with(
                     'content' => /^env: foo\n/,
                 )}
+                it { should contain_concat__fragment('datadog apm footer').with(
+                    'order' => '06',
+                )}
             end
             context 'with service_discovery enabled' do
                 let(:params) {
@@ -591,6 +594,20 @@ describe 'datadog_agent' do
                 )}
                 it { should contain_concat__fragment('datadog footer').with(
                 'content' => /^sd_jmx_enable: true\n/,
+                )}
+            end
+            context 'with extra_template enabled' do
+                let(:params) {
+                    {:extra_template => 'custom_datadog/extra_template_test.erb',
+                }}
+                it { should contain_concat__fragment('datadog extra_template footer').with(
+                'order' => '06',
+                )}
+                it { should contain_concat__fragment('datadog extra_template footer').with(
+                'content' => /^# extra template is here\n/,
+                )}
+                it { should contain_concat__fragment('datadog apm footer').with(
+                'order' => '07',
                 )}
             end
             end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -218,21 +218,24 @@ describe 'datadog_agent' do
                     'content' => /^dd_url: https:\/\/notaurl.datadoghq.com\n/,
                 )}
             end
-
             context 'with a custom proxy_host' do
                 let(:params) {{:proxy_host => 'localhost'}}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^proxy_host: localhost\n/,
                 )}
             end
-
             context 'with a custom proxy_port' do
                 let(:params) {{:proxy_port => '1234'}}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^proxy_port: 1234\n/,
                 )}
             end
-
+            context 'with a custom proxy_port, specified as an integer' do
+                let(:params) {{:proxy_port => 1234}}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^proxy_port: 1234\n/,
+                )}
+            end
             context 'with a custom proxy_user' do
                 let(:params) {{:proxy_user => 'notauser'}}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
@@ -245,7 +248,6 @@ describe 'datadog_agent' do
                     'content' => /^api_key: notakey\n/,
                 )}
             end
-
             context 'with a custom hostname' do
                 let(:params) {{:host => 'notahost'}}
 
@@ -259,7 +261,7 @@ describe 'datadog_agent' do
                     'content' => /^non_local_traffic: true\n/,
                 )}
             end
-            #Should expand testing to cover changes to the case upcase 
+            #Should expand testing to cover changes to the case upcase
             context 'with log level set to critical' do
                 let(:params) {{:log_level => 'critical'}}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
@@ -279,56 +281,67 @@ describe 'datadog_agent' do
                 )}
             end
             context 'with skip_ssl_validation set to true' do
-                let(:params) {{:skip_ssl_validation => true }} 
+                let(:params) {{:skip_ssl_validation => true }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^skip_ssl_validation: true\n/,
                 )}
             end
             context 'with collect_ec2_tags set to yes' do
-                let(:params) {{:collect_ec2_tags => true }} 
+                let(:params) {{:collect_ec2_tags => true }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^collect_ec2_tags: true\n/,
                 )}
             end
             context 'with collect_instance_metadata set to no' do
-                let(:params) {{:collect_instance_metadata => false }} 
+                let(:params) {{:collect_instance_metadata => false }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^collect_instance_metadata: false\n/,
                 )}
             end
             context 'with recent_point_threshold set to 60' do
-                let(:params) {{:recent_point_threshold => '60' }} 
+                let(:params) {{:recent_point_threshold => '60' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^recent_point_threshold: 60\n/,
                 )}
             end
             context 'with a custom port set to 17125' do
-                let(:params) {{:listen_port => '17125' }} 
+                let(:params) {{:listen_port => '17125' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^listen_port: 17125\n/,
                 )}
             end
-            context 'litstening for graphite data on port 17124' do
-                let(:params) {{:graphite_listen_port => '17124' }} 
+            context 'with a custom port set to 17125, specified as an integer' do
+                let(:params) {{:listen_port => 17125 }}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^listen_port: 17125\n/,
+                )}
+            end
+            context 'listening for graphite data on port 17124' do
+                let(:params) {{:graphite_listen_port => '17124' }}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^graphite_listen_port: 17124\n/,
+                )}
+            end
+            context 'listening for graphite data on port 17124, port specified as an integer' do
+                let(:params) {{:graphite_listen_port => 17124 }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^graphite_listen_port: 17124\n/,
                 )}
             end
             context 'with configuration for a custom checks.d' do
-                let(:params) {{:additional_checksd => '/etc/dd-agent/checks_custom.d'  }} 
+                let(:params) {{:additional_checksd => '/etc/dd-agent/checks_custom.d' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^additional_checksd: \/etc\/dd-agent\/checks_custom.d\n/,
                 )}
             end
             context 'with configuration for a custom checks.d' do
-                let(:params) {{:additional_checksd => '/etc/dd-agent/checks_custom.d'  }} 
+                let(:params) {{:additional_checksd => '/etc/dd-agent/checks_custom.d' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^additional_checksd: \/etc\/dd-agent\/checks_custom.d\n/,
                 )}
             end
-
             context 'with configuration for a custom checks.d' do
-                let(:params) {{:additional_checksd => '/etc/dd-agent/checks_custom.d'  }} 
+                let(:params) {{:additional_checksd => '/etc/dd-agent/checks_custom.d' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^additional_checksd: \/etc\/dd-agent\/checks_custom.d\n/,
                 )}
@@ -357,28 +370,32 @@ describe 'datadog_agent' do
                     'content' => /^pup_port: 17126\n/,
                 )}
             end
+            context 'with a custom pup_port, specified as an integer' do
+                let(:params) {{:pup_port => 17126 }}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^pup_port: 17126\n/,
+                )}
+            end
             context 'with a custom pup_interface' do
                 let(:params) {{:pup_interface => 'notalocalhost' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^pup_interface: notalocalhost\n/,
                 )}
             end
-
             context 'with a custom pup_url' do
                 let(:params) {{:pup_url => 'http://localhost:17126' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^pup_url: http:\/\/localhost:17126\n/,
                 )}
             end
-
             context 'with use_dogstatsd set to no' do
                 let(:params) {{:use_dogstatsd => false}}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^use_dogstatsd: no\n/,
                 )}
             end
-            context 'with dogstatsd_port set to 8126' do
-                let(:params) {{:dogstatsd_port  => 8126}}
+            context 'with dogstatsd_port set to 8126 - must be specified as an integer!' do
+                let(:params) {{:dogstatsd_port => 8126 }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^dogstatsd_port: 8126\n/,
                 )}
@@ -414,13 +431,13 @@ describe 'datadog_agent' do
                 )}
             end
             context 'with statsd_forward_port set to 8126' do
-                let(:params) {{:statsd_forward_port  => '8126' }}
+                let(:params) {{:statsd_forward_port => '8126' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^statsd_forward_port: 8126\n/,
                 )}
             end
-            context 'with statsd_forward_port set to 8126' do
-                let(:params) {{:statsd_forward_port  => '8126' }}
+            context 'with statsd_forward_port set to 8126, specified as an integer' do
+                let(:params) {{:statsd_forward_port => 8126 }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^statsd_forward_port: 8126\n/,
                 )}
@@ -438,12 +455,18 @@ describe 'datadog_agent' do
                 )}
             end
             context 'with ganglia_host set to localhost and ganglia_port set to 12345' do
-                let(:params) {{:ganglia_host  => 'testhost', :ganglia_port => '12345' }}
+                let(:params) {{:ganglia_host => 'testhost', :ganglia_port => '12345' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^ganglia_port: 12345\n/,
                 )}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^ganglia_host: testhost\n/,
+                )}
+            end
+            context 'with ganglia_host set to localhost and ganglia_port set to 12345, port specified as an integer' do
+                let(:params) {{:ganglia_host => 'testhost', :ganglia_port => 12345 }}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^ganglia_port: 12345\n/,
                 )}
             end
             context 'with dogstreams set to /path/to/log1:/path/to/parser' do
@@ -501,7 +524,13 @@ describe 'datadog_agent' do
                 )}
             end
             context 'with syslog port set to 8080' do
-                let(:params) {{:syslog_port  => '8080' }}
+                let(:params) {{:syslog_port => '8080' }}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^syslog_port: 8080\n/,
+                )}
+            end
+            context 'with syslog port set to 8080, specified as an integer' do
+                let(:params) {{:syslog_port => 8080 }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^syslog_port: 8080\n/,
                 )}

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -39,173 +39,174 @@ describe 'datadog_agent' do
         end
 
         it { should contain_file('/etc/dd-agent') }
-        it { should contain_file('/etc/dd-agent/datadog.conf') }
+        it { should contain_concat('/etc/dd-agent/datadog.conf') }
+        it { should contain_file('/etc/dd-agent/conf.d').with_ensure('directory') }
 
         it { should contain_class('datadog_agent::reports') }
 
         describe 'parameter check' do
             context 'with defaults' do
                 context 'for proxy' do
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog header').with(
                     'content' => /^dd_url: https:\/\/app.datadoghq.com\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog header').with(
                     'content' => /^# proxy_host:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog header').with(
                     'content' => /^# proxy_port:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog header').with(
                     'content' => /^# proxy_user:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog header').with(
                     'content' => /^# proxy_password:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog header').with(
                     'content' => /^# skip_ssl_validation: no\n/,
                     )}
                 end
 
                 context 'for general' do
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog header').with(
                     'content' => /^api_key: your_API_key\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog header').with(
                     'content' => /^# hostname:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^non_local_traffic: false\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^collect_ec2_tags: false\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^collect_instance_metadata: true\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /# recent_point_threshold: 30\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# listen_port: 17123\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# graphite_listen_port: 17124\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# additional_checksd: \/etc\/dd-agent\/checks.d\/\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^use_curl_http_client: false\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# device_blacklist_re: .*\\\/dev\\\/mapper\\\/lxc-box.*\n/,
                     )}
                 end
 
                 context 'for pup' do
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^use_pup: no\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# pup_port: 17125\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# pup_interface: localhost\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# pup_url: http:\/\/localhost:17125\n/,
                     )}
                 end
 
                 context 'for dogstatsd' do
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# bind_host: localhost\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^use_dogstatsd: yes\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^dogstatsd_port: 8125\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# dogstatsd_target: http:\/\/localhost:17123\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# dogstatsd_interval: 10\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^dogstatsd_normalize: yes\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# statsd_forward_host: address_of_own_statsd_server\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# statsd_forward_port: 8125\n/,
                     )}
                 end
 
                 context 'for ganglia' do
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# ganglia_host: localhost\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# ganglia_port: 8651\n/,
                     )}
                 end
 
                 context 'for logging' do
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^log_level: INFO\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^log_to_syslog: yes\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# collector_log_file: \/var\/log\/datadog\/collector.log\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# forwarder_log_file: \/var\/log\/datadog\/forwarder.log\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# dogstatsd_log_file: \/var\/log\/datadog\/dogstatsd.log\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     #'content' => /^# pup_log_file:        \/var\/log\/datadog\/pup.log\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# syslog_host:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^# syslog_port:\n/,
                     )}
                 end
 
                 context 'for service_discovery' do
-                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    it { should contain_concat__fragment('datadog footer').without(
                     'content' => /^service_discovery_backend:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    it { should contain_concat__fragment('datadog footer').without(
                     'content' => /^sd_config_backend:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    it { should contain_concat__fragment('datadog footer').without(
                     'content' => /^sd_backend_host:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    it { should contain_concat__fragment('datadog footer').without(
                     'content' => /^sd_backend_port:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    it { should contain_concat__fragment('datadog footer').without(
                     'content' => /^sd_template_dir:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    it { should contain_concat__fragment('datadog footer').without(
                     'content' => /^consul_token:\n/,
                     )}
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
-                    'content' => /^# sd_jmx_enable: no\n/,
+                    it { should contain_concat__fragment('datadog footer').without(
+                    'content' => /^# sd_jmx_enable:\n/,
                     )}
                 end
 
                 context 'for APM' do
-                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^apm_enabled: false\n/,
                     )}
                 end
@@ -214,330 +215,342 @@ describe 'datadog_agent' do
             context 'with user provided paramaters' do
             context 'with a custom dd_url' do
                 let(:params) {{:dd_url => 'https://notaurl.datadoghq.com'}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog header').with(
                     'content' => /^dd_url: https:\/\/notaurl.datadoghq.com\n/,
                 )}
             end
             context 'with a custom proxy_host' do
                 let(:params) {{:proxy_host => 'localhost'}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog header').with(
                     'content' => /^proxy_host: localhost\n/,
                 )}
             end
             context 'with a custom proxy_port' do
                 let(:params) {{:proxy_port => '1234'}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog header').with(
                     'content' => /^proxy_port: 1234\n/,
                 )}
             end
             context 'with a custom proxy_port, specified as an integer' do
                 let(:params) {{:proxy_port => 1234}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog header').with(
                     'content' => /^proxy_port: 1234\n/,
                 )}
             end
             context 'with a custom proxy_user' do
                 let(:params) {{:proxy_user => 'notauser'}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog header').with(
                     'content' => /^proxy_user: notauser\n/,
                 )}
             end
             context 'with a custom api_key' do
                 let(:params) {{:api_key => 'notakey'}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog header').with(
                     'content' => /^api_key: notakey\n/,
                 )}
             end
             context 'with a custom hostname' do
                 let(:params) {{:host => 'notahost'}}
 
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog header').with(
                     'content' => /^hostname: notahost\n/,
                 )}
             end
             context 'with non_local_traffic set to true' do
                 let(:params) {{:non_local_traffic => true}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^non_local_traffic: true\n/,
                 )}
             end
             #Should expand testing to cover changes to the case upcase
             context 'with log level set to critical' do
                 let(:params) {{:log_level => 'critical'}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^log_level: CRITICAL\n/,
                 )}
             end
             context 'with a custom hostname' do
                 let(:params) {{:host => 'notahost'}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog header').with(
                     'content' => /^hostname: notahost\n/,
                 )}
             end
             context 'with log_to_syslog set to false' do
                 let(:params) {{:log_to_syslog => false}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^log_to_syslog: no\n/,
                 )}
             end
             context 'with skip_ssl_validation set to true' do
                 let(:params) {{:skip_ssl_validation => true }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog header').with(
                     'content' => /^skip_ssl_validation: true\n/,
                 )}
             end
             context 'with collect_ec2_tags set to yes' do
                 let(:params) {{:collect_ec2_tags => true }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^collect_ec2_tags: true\n/,
                 )}
             end
             context 'with collect_instance_metadata set to no' do
                 let(:params) {{:collect_instance_metadata => false }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^collect_instance_metadata: false\n/,
                 )}
             end
             context 'with recent_point_threshold set to 60' do
                 let(:params) {{:recent_point_threshold => '60' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^recent_point_threshold: 60\n/,
                 )}
             end
             context 'with a custom port set to 17125' do
                 let(:params) {{:listen_port => '17125' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^listen_port: 17125\n/,
                 )}
             end
             context 'with a custom port set to 17125, specified as an integer' do
                 let(:params) {{:listen_port => 17125 }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^listen_port: 17125\n/,
                 )}
             end
             context 'listening for graphite data on port 17124' do
                 let(:params) {{:graphite_listen_port => '17124' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^graphite_listen_port: 17124\n/,
                 )}
             end
             context 'listening for graphite data on port 17124, port specified as an integer' do
                 let(:params) {{:graphite_listen_port => 17124 }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^graphite_listen_port: 17124\n/,
                 )}
             end
             context 'with configuration for a custom checks.d' do
                 let(:params) {{:additional_checksd => '/etc/dd-agent/checks_custom.d' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^additional_checksd: \/etc\/dd-agent\/checks_custom.d\n/,
                 )}
             end
             context 'with configuration for a custom checks.d' do
                 let(:params) {{:additional_checksd => '/etc/dd-agent/checks_custom.d' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^additional_checksd: \/etc\/dd-agent\/checks_custom.d\n/,
                 )}
             end
             context 'with configuration for a custom checks.d' do
                 let(:params) {{:additional_checksd => '/etc/dd-agent/checks_custom.d' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^additional_checksd: \/etc\/dd-agent\/checks_custom.d\n/,
                 )}
             end
             context 'with using the Tornado HTTP client' do
                 let(:params) {{:use_curl_http_client => true }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^use_curl_http_client: true\n/,
                 )}
             end
             context 'with a custom bind_host' do
                 let(:params) {{:bind_host => 'test'  }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^bind_host: test\n/,
                 )}
             end
             context 'with pup enabled' do
                 let(:params) {{:use_pup => true }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^use_pup: yes\n/,
                 )}
             end
             context 'with a custom pup_port' do
                 let(:params) {{:pup_port => '17126' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^pup_port: 17126\n/,
                 )}
             end
             context 'with a custom pup_port, specified as an integer' do
                 let(:params) {{:pup_port => 17126 }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^pup_port: 17126\n/,
                 )}
             end
             context 'with a custom pup_interface' do
                 let(:params) {{:pup_interface => 'notalocalhost' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^pup_interface: notalocalhost\n/,
                 )}
             end
             context 'with a custom pup_url' do
                 let(:params) {{:pup_url => 'http://localhost:17126' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^pup_url: http:\/\/localhost:17126\n/,
                 )}
             end
             context 'with use_dogstatsd set to no' do
                 let(:params) {{:use_dogstatsd => false}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^use_dogstatsd: no\n/,
+                )}
+            end
+            context 'with use_dogstatsd set to yes' do
+                let(:params) {{:use_dogstatsd => true}}
+                it { should contain_concat__fragment('datadog footer').with(
+                    'content' => /^use_dogstatsd: yes\n/,
                 )}
             end
             context 'with dogstatsd_port set to 8126 - must be specified as an integer!' do
                 let(:params) {{:dogstatsd_port => 8126 }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
+                    'content' => /^dogstatsd_port: 8126\n/,
+                )}
+            end
+            context 'with dogstatsd_port set to 8126' do
+                let(:params) {{:dogstatsd_port  => 8126}}
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^dogstatsd_port: 8126\n/,
                 )}
             end
             context 'with dogstatsd_target set to localhost:17124' do
                 let(:params) {{:dogstatsd_target  => 'http://localhost:17124'}}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^dogstatsd_target: http:\/\/localhost:17124\n/,
                 )}
             end
             context 'with dogstatsd_interval set to 5' do
                 let(:params) {{:dogstatsd_interval  => '5' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^dogstatsd_interval: 5\n/,
                 )}
             end
             context 'with dogstatsd_interval set to 5' do
                 let(:params) {{:dogstatsd_interval  => '5' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^dogstatsd_interval: 5\n/,
                 )}
             end
             context 'with dogstatsd_normalize set to false' do
                 let(:params) {{:dogstatsd_normalize  => false }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^dogstatsd_normalize: no\n/,
                 )}
             end
             context 'with statsd_forward_host set to localhost:3958' do
                 let(:params) {{:statsd_forward_host  => 'localhost:3958' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^statsd_forward_host: localhost:3958\n/,
                 )}
             end
             context 'with statsd_forward_port set to 8126' do
                 let(:params) {{:statsd_forward_port => '8126' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^statsd_forward_port: 8126\n/,
                 )}
             end
             context 'with statsd_forward_port set to 8126, specified as an integer' do
                 let(:params) {{:statsd_forward_port => 8126 }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^statsd_forward_port: 8126\n/,
                 )}
             end
             context 'with device_blacklist_re set to test' do
                 let(:params) {{:device_blacklist_re  => 'test' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^device_blacklist_re: test\n/,
                 )}
             end
             context 'with device_blacklist_re set to test' do
                 let(:params) {{:device_blacklist_re  => 'test' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^device_blacklist_re: test\n/,
                 )}
             end
             context 'with ganglia_host set to localhost and ganglia_port set to 12345' do
                 let(:params) {{:ganglia_host => 'testhost', :ganglia_port => '12345' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^ganglia_port: 12345\n/,
                 )}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^ganglia_host: testhost\n/,
                 )}
             end
             context 'with ganglia_host set to localhost and ganglia_port set to 12345, port specified as an integer' do
                 let(:params) {{:ganglia_host => 'testhost', :ganglia_port => 12345 }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^ganglia_port: 12345\n/,
                 )}
             end
             context 'with dogstreams set to /path/to/log1:/path/to/parser' do
                 let(:params) {{:dogstreams  => ['/path/to/log1:/path/to/parser'] }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^dogstreams: \/path\/to\/log1:\/path\/to\/parser\n/,
                 )}
             end
             context 'with custom_emitters set to /test/emitter' do
                 let(:params) {{:custom_emitters  => '/test/emitter/' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^custom_emitters: \/test\/emitter\/\n/,
                 )}
             end
             context 'with custom_emitters set to /test/emitter' do
                 let(:params) {{:custom_emitters  => '/test/emitter/' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^custom_emitters: \/test\/emitter\/\n/,
                 )}
             end
             context 'with collector_log_file set to /test/log' do
                 let(:params) {{:collector_log_file  => '/test/log' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^collector_log_file: \/test\/log\n/,
                 )}
             end
             context 'with forwarder_log_file set to /test/log' do
                 let(:params) {{:forwarder_log_file  => '/test/log' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^forwarder_log_file: \/test\/log\n/,
                 )}
             end
             context 'with forwarder_log_file set to /test/log' do
                 let(:params) {{:forwarder_log_file  => '/test/log' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^forwarder_log_file: \/test\/log\n/,
                 )}
             end
             context 'with dogstatsd_log_file set to /test/log' do
                 let(:params) {{:dogstatsd_log_file  => '/test/log' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^dogstatsd_log_file: \/test\/log\n/,
                 )}
             end
             context 'with pup_log_file set to /test/log' do
                 let(:params) {{:pup_log_file  => '/test/log' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^pup_log_file: \/test\/log\n/,
                 )}
             end
             context 'with syslog location set to localhost' do
                 let(:params) {{:syslog_host  => 'localhost' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^syslog_host: localhost\n/,
                 )}
             end
             context 'with syslog port set to 8080' do
                 let(:params) {{:syslog_port => '8080' }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^syslog_port: 8080\n/,
                 )}
             end
             context 'with syslog port set to 8080, specified as an integer' do
                 let(:params) {{:syslog_port => 8080 }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^syslog_port: 8080\n/,
                 )}
             end
             context 'with apm_enabled set to true' do
                 let(:params) {{:apm_enabled  => true }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^apm_enabled: true\n/,
                 )}
             end
@@ -546,13 +559,13 @@ describe 'datadog_agent' do
                     {:apm_enabled  => true,
                      :apm_env => 'foo',
                 }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                     'content' => /^apm_enabled: true\n/,
                 )}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog apm footer').with(
                     'content' => /^\[trace.agent\]\n/,
                 )}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog apm footer').with(
                     'content' => /^env: foo\n/,
                 )}
             end
@@ -564,19 +577,19 @@ describe 'datadog_agent' do
                      :sd_backend_port            => '8080',
                      :sd_jmx_enable              =>  true,
                 }}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                 'content' => /^service_discovery_backend: docker\n/,
                 )}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                 'content' => /^sd_config_backend: etcd\n/,
                 )}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                 'content' => /^sd_backend_host: localhost\n/,
                 )}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                 'content' => /^sd_backend_port: 8080\n/,
                 )}
-                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                it { should contain_concat__fragment('datadog footer').with(
                 'content' => /^sd_jmx_enable: true\n/,
                 )}
             end
@@ -588,6 +601,22 @@ describe 'datadog_agent' do
         elsif REDHAT_OS.include?(operatingsystem)
           it { should contain_class('datadog_agent::redhat') }
         end
+      end
+    end
+  end
+
+  context "with facts to tags set" do
+    describe "ensure facts_array outputs a list of tags" do
+      let(:params) { { puppet_run_reports: true, puppet_gem_provider: 'gem', facts_to_tags: ['osfamily', 'facts_array']} }
+      let(:facts) do
+        {
+            operatingsystem: 'CentOS',
+            osfamily: 'redhat',
+            facts_array: ['one', 'two', 'three']
+        }
+
+        it { should contain_concat('/etc/dd-agent/datadog.conf') }
+        it { should contain_concat__fragment('datadog tags').with(/tags: osfamily:redhat, facts_array:one, facts_array:two, facts_array:three/) }
       end
     end
   end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -203,6 +203,12 @@ describe 'datadog_agent' do
                     'content' => /^# sd_jmx_enable: no\n/,
                     )}
                 end
+
+                context 'for APM' do
+                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^apm_enabled: false\n/,
+                    )}
+                end
             end
 
             context 'with user provided paramaters' do
@@ -498,6 +504,12 @@ describe 'datadog_agent' do
                 let(:params) {{:syslog_port  => '8080' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^syslog_port: 8080\n/,
+                )}
+            end
+            context 'with apm_enabled set to true' do
+                let(:params) {{:apm_enabled  => true }}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^apm_enabled: true\n/,
                 )}
             end
             context 'with service_discovery enabled' do

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -512,6 +512,21 @@ describe 'datadog_agent' do
                     'content' => /^apm_enabled: true\n/,
                 )}
             end
+            context 'with apm_enabled set to true and env specified' do
+                let(:params) {
+                    {:apm_enabled  => true,
+                     :apm_env => 'foo',
+                }}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^apm_enabled: true\n/,
+                )}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^\[trace.agent\]\n/,
+                )}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^env: foo\n/,
+                )}
+            end
             context 'with service_discovery enabled' do
                 let(:params) {
                     {:service_discovery_backend  => 'docker',

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -199,6 +199,9 @@ describe 'datadog_agent' do
                     it { should contain_file('/etc/dd-agent/datadog.conf').without(
                     'content' => /^consul_token:\n/,
                     )}
+                    it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                    'content' => /^# sd_jmx_enable: no\n/,
+                    )}
                 end
             end
 
@@ -503,6 +506,7 @@ describe 'datadog_agent' do
                      :sd_config_backend          => 'etcd',
                      :sd_backend_host            => 'localhost',
                      :sd_backend_port            => '8080',
+                     :sd_jmx_enable              =>  true,
                 }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                 'content' => /^service_discovery_backend: docker\n/,
@@ -515,6 +519,9 @@ describe 'datadog_agent' do
                 )}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                 'content' => /^sd_backend_port: 8080\n/,
+                )}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                'content' => /^sd_jmx_enable: true\n/,
                 )}
             end
             end

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -14,8 +14,8 @@ describe 'datadog_agent::ubuntu' do
   end
 
   # it should install the mirror
-  it { should contain_datadog_agent__ubuntu__install_key('C7A7DA52') }
-  it { should contain_datadog_agent__ubuntu__install_key('382E94DE') }
+  it { should contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
+  it { should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
   it do
     should contain_file('/etc/apt/sources.list.d/datadog.list')\
       .that_notifies('Exec[datadog_apt-get_update]')

--- a/spec/custom_fixtures/custom_datadog/templates/extra_template_test.erb
+++ b/spec/custom_fixtures/custom_datadog/templates/extra_template_test.erb
@@ -1,0 +1,1 @@
+# extra template is here

--- a/templates/agent-conf.d/ceph.yaml.erb
+++ b/templates/agent-conf.d/ceph.yaml.erb
@@ -1,10 +1,14 @@
 init_config:
 
 instances:
+<% if @tags and ! @tags.empty? -%>
   - tags:
-    - name:ceph_cluster
+  <%- @tags.each do |tag| -%>
+    - <%= tag %>
+  <%- end -%>
+<% end -%>
 
-    ceph_cmd: /usr/bin/ceph
+    ceph_cmd: <%= @ceph_cmd %>
 
 # If your environment requires sudo, please add a line like:
 #          dd-agent ALL=(ALL) NOPASSWD:/usr/bin/ceph

--- a/templates/agent-conf.d/ceph.yaml.erb
+++ b/templates/agent-conf.d/ceph.yaml.erb
@@ -1,0 +1,13 @@
+init_config:
+
+instances:
+  - tags:
+    - name:ceph_cluster
+
+    ceph_cmd: /usr/bin/ceph
+
+# If your environment requires sudo, please add a line like:
+#          dd-agent ALL=(ALL) NOPASSWD:/usr/bin/ceph
+# to your sudoers file, and uncomment the below option.
+
+    use_sudo: True

--- a/templates/agent-conf.d/consul.yaml.erb
+++ b/templates/agent-conf.d/consul.yaml.erb
@@ -37,7 +37,7 @@ instances:
       #  - zookeeper
       #  - gunicorn
       #  - redis
-      <% if @service_whitelist and ! @service_whitelist.empty? -%>
+      <%- if @service_whitelist and ! @service_whitelist.empty? -%>
       service_whitelist:
         <%- Array(@service_whitelist).each do |svc| -%>
           <%- if svc != '' -%>

--- a/templates/agent-conf.d/docker_daemon.yaml.erb
+++ b/templates/agent-conf.d/docker_daemon.yaml.erb
@@ -80,10 +80,10 @@ instances:
     ## Tagging
     ##
 <% if @tags and ! @tags.empty? -%>
-      tags:
+    tags:
   <%- Array(@tags).each do |tag| -%>
     <%- if tag != '' -%>
-          - <%= tag %>
+       - <%= tag %>
     <%- end -%>
   <%- end -%>
 <% end -%>

--- a/templates/agent-conf.d/elastic.yaml.erb
+++ b/templates/agent-conf.d/elastic.yaml.erb
@@ -5,28 +5,30 @@
 init_config:
 
 instances:
-    - url: <%= @url %>
-<%- if @username -%>
-      username: <%= @username %>
+<%- (Array(@_instances)).each do |instance| -%>
+    - url: <%= instance['url'] %>
+<%- if instance['username'] && instance['username'] != :undef -%>
+      username: <%= instance['username'] %>
 <%- end -%>
-<%- if @password -%>
-      password: <%= @password %>
+<%- if instance['password'] && instance['password'] != :undef -%>
+      password: <%= instance['password'] %>
 <%- end -%>
-      cluster_stats: <%= @cluster_stats %>
-      pshard_stats: <%= @pshard_stats %>
-      pending_task_stats: <%= @pending_task_stats %>
-<%- if @url.match(/^https/) -%>
-      ssl_verify: <%= @ssl_verify %>
+      cluster_stats: <%= instance['cluster_stats'] %>
+      pshard_stats: <%= instance['pshard_stats'] %>
+      pending_task_stats: <%= instance['pending_task_stats'] %>
+<%- if instance['url'].match(/^https/) -%>
+      ssl_verify: <%= instance['ssl_verify'] %>
 <%- end -%>
-<%- if @ssl_cert -%>
-      ssl_cert: <%= @ssl_cert %>
+<%- if instance['ssl_cert'] && instance['ssl_cert'] != :undef -%>
+      ssl_cert: <%= instance['ssl_cert'] %>
 <%- end -%>
-<%- if @ssl_key -%>
-      ssl_key: <%= @ssl_key %>
+<%- if instance['ssl_key'] && instance['ssl_key'] != :undef -%>
+      ssl_key: <%= instance['ssl_key'] %>
 <%- end -%>
-<%- unless @tags.empty? -%>
+<%- unless instance['tags'].empty? -%>
       tags:
-  <%- @tags.each do |tag| -%>
+  <%- instance['tags'].each do |tag| -%>
         - <%= tag %>
   <%- end -%>
+<%- end -%>
 <%- end -%>

--- a/templates/agent-conf.d/haproxy.yaml.erb
+++ b/templates/agent-conf.d/haproxy.yaml.erb
@@ -13,4 +13,9 @@ instances:
       <%= k %>: <%= v %>
       <%- end -%>
     <%- end -%>
+    <%- if instance['options'] -%>
+      <%- instance['options'].each do |k, v| -%>
+      <%= k %>: <%= v %>
+      <%- end -%>
+    <%- end -%>
 <% end -%>

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -34,6 +34,9 @@ instances:
 <% if instance['skip_event'] -%>
     skip_event: <%= instance['skip_event'] %>
 <% end -%>
+<% if instance['no_proxy'] -%>
+    no_proxy: <%= instance['no_proxy'] %>
+<% end -%>
 <% if instance['check_certificate_expiration'] -%>
     check_certificate_expiration: <%= instance['check_certificate_expiration'] %>
 <% if instance['check_certificate_expiration'] == true -%>

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -25,6 +25,9 @@ instances:
 <% if instance['include_content'] -%>
     include_content: <%= instance['include_content'] %>
 <% end -%>
+<% if instance['http_response_status_code'] -%>
+    http_response_status_code: <%= instance['http_response_status_code'] %>
+<% end -%>
 <% if instance['collect_response_time'] -%>
     collect_response_time: <%= instance['collect_response_time'] %>
 <% end -%>

--- a/templates/agent-conf.d/mcache.yaml.erb
+++ b/templates/agent-conf.d/mcache.yaml.erb
@@ -1,17 +1,23 @@
+#
+# MANAGED BY PUPPET
+#
+
 init_config:
 
 instances:
-    -   url: <%= @url %>
-        port: <%= @port %>
-<% if @tags and ! @tags.empty? -%>
-        tags:
-  <%- Array(@tags).each do |tag| -%>
+<%- (Array(@_instances)).each do |instance| -%>
+  - url: <%= instance['url'] %>
+    port: <%= instance['port'] %>
+<% if instance['tags'] and ! instance['tags'].empty? -%>
+    tags:
+  <%- Array(instance['tags']).each do |tag| -%>
     <%- if tag != '' -%>
-            - <%= tag %>
+      - <%= tag %>
     <%- end -%>
   <%- end -%>
 <% end -%>
 
-options:
-  items: <%= @items %>
-  slabs: <%= @slabs %>
+    options:               # Optional
+        items: <%= instance['items'] %>
+        slabs: <%= instance['slabs'] %>
+<% end -%>

--- a/templates/agent-conf.d/mongo.yaml.erb
+++ b/templates/agent-conf.d/mongo.yaml.erb
@@ -34,4 +34,10 @@ instances:
       - <%= additional_metric %>
     <%- end -%>
   <%- end -%>
+  <%- if !server['collections'].nil? && server['collections'].any? -%>
+    collections:
+    <%- server['collections'].each do |collection| -%>
+      - <%= collection %>
+    <%- end -%>
+  <%- end -%>
 <% end -%>

--- a/templates/agent-conf.d/php_fpm.yaml.erb
+++ b/templates/agent-conf.d/php_fpm.yaml.erb
@@ -4,12 +4,17 @@
 init_config:
 
 instances:
+<%- (Array(@_instances)).each do |instance| -%>
   - # Get metrics from your FPM pool with this URL
-    status_url: <%= @status_url %>
+    status_url: <%= instance['status_url'] %>
     # Get a reliable service check of your FPM pool with that one
-    ping_url: <%= @ping_url %>
+    ping_url: <%= instance['ping_url'] %>
     # Set the expected reply to the ping.
     ping_reply: pong
+    <%- if instance['http_host'] -%>
+    # Set http host header
+    http_host: <%= instance['http_host'] %>
+    <%- end -%>
     # These 2 URLs should follow the options from your FPM pool
     # See http://php.net/manual/en/install.fpm.configuration.php
     #   * pm.status_path
@@ -19,11 +24,12 @@ instances:
     # you want to monitor (FPM `listen` directive in the config, usually
     # a UNIX socket or TCP socket.
     #
-<% if @tags and !@tags.empty? -%>
+<%- if instance['tags'] and !instance['tags'].empty? -%>
     # Array of custom tags
     # By default metrics and service check will be tagged by pool and host
     tags:
-    <% @tags.each do |tag| -%>
+    <%- instance['tags'].each do |tag| -%>
       - <%= tag %>
-    <% end -%>
+    <%- end -%>
+<%- end -%>
 <% end -%>

--- a/templates/agent-conf.d/postfix.yaml.erb
+++ b/templates/agent-conf.d/postfix.yaml.erb
@@ -1,0 +1,26 @@
+#
+# MANAGED BY PUPPET
+#
+
+init_config:
+
+instances:
+<%- (Array(@_instances)).each do |instance| -%>
+  - directory: <%= instance['directory'] %>
+<% if instance['queues'] and ! instance['queues'].empty? -%>
+    queues:
+  <%- Array(instance['queues']).each do |queue| -%>
+    <%- if queue != '' -%>
+      - <%= queue %>
+    <%- end -%>
+  <%- end -%>
+<%- end -%>
+<% if instance['tags'] and ! instance['tags'].empty? -%>
+    tags:
+  <%- Array(instance['tags']).each do |tag| -%>
+    <%- if tag != '' -%>
+      - <%= tag %>
+    <%- end -%>
+  <%- end -%>
+<% end -%>
+<% end -%>

--- a/templates/agent-conf.d/rabbitmq.yaml.erb
+++ b/templates/agent-conf.d/rabbitmq.yaml.erb
@@ -2,22 +2,40 @@ init_config:
 
 instances:
     -  rabbitmq_api_url: <%= @url %>
-<% if @username -%>
        rabbitmq_user: <%= @username %>
-<% end -%>
-<% if @password -%>
        rabbitmq_pass: <%= @password %>
+       ssl_verify: <%= @ssl_verify %>
+       tag_families: <%= @tag_families %>
+
+<% unless @nodes.empty?  -%>
+       nodes:
+<% @nodes.each do |x| -%>
+         - <%= x %>
+<% end -%>
 <% end -%>
 
-<% if @queues  -%>
+<% unless @nodes_regexes.empty?  -%>
+       nodes_regexes:
+<% @nodes_regexes.each do |x| -%>
+         - <%= x %>
+<% end -%>
+<% end -%>
+
+<% unless @queues.empty?  -%>
        queues:
 <% @queues.each do |x| -%>
          - <%= x %>
 <% end -%>
 <% end -%>
 
+<% unless @queues_regexes.empty?  -%>
+       queues_regexes:
+<% @queues_regexes.each do |x| -%>
+         - <%= x %>
+<% end -%>
+<% end -%>
 
-<% if @vhosts -%>
+<% unless @vhosts.empty? -%>
        vhosts:
 <% @vhosts.each do |x| -%>
          - <%= x %>

--- a/templates/agent-conf.d/redisdb.yaml.erb
+++ b/templates/agent-conf.d/redisdb.yaml.erb
@@ -9,6 +9,7 @@ instances:
   - host: <%= @host %>
     port: <%= port %>
     warn_on_missing_keys: <%= @warn_on_missing_keys %>
+    command_stats: <%= @command_stats %>
     <% if @password.empty? %># <%end %>password: <%= @password %>
     # unix_socket_path: /var/run/redis/redis.sock # optional, can be used in lieu of host/port
     <% if @slowlog_max_len.empty? %># <%end %>slowlog-max-len: <%= @slowlog_max_len %>

--- a/templates/agent-conf.d/tcp_check.yaml.erb
+++ b/templates/agent-conf.d/tcp_check.yaml.erb
@@ -1,0 +1,31 @@
+init_config:
+
+instances:
+<%- (Array(@_instances)).each do |instance| -%>
+  - name: <%= instance['check_name'] %>
+    host: <%= instance['host'] %>
+    port: <%= instance['port'] %>
+<% if instance['timeout'] -%>
+    timeout: <%= instance['timeout'] %>
+<% end -%>
+<% if instance['threshold'] -%>
+    threshold: <%= instance['threshold'] %>
+<% end -%>
+<% if instance['window'] -%>
+    window: <%= instance['window'] %>
+<% end -%>
+<% if instance['collect_response_time'] -%>
+    collect_response_time: <%= instance['collect_response_time'] %>
+<% end -%>
+<% if instance['skip_event'] -%>
+    skip_event: <%= instance['skip_event'] %>
+<% end -%>
+<% if instance['tags'] and ! instance['tags'].empty? -%>
+    tags:
+  <%- Array(instance['tags']).each do |tag| -%>
+    <%- if tag != '' -%>
+      - <%= tag %>
+    <%- end -%>
+  <%- end -%>
+<% end -%>
+<% end -%>

--- a/templates/agent-conf.d/twemproxy.yaml.erb
+++ b/templates/agent-conf.d/twemproxy.yaml.erb
@@ -1,0 +1,11 @@
+#
+# MANAGED BY PUPPET
+#
+
+init_config:
+
+instances:
+<%- (Array(@_instances)).each do |instance| -%>
+  - host: <%= instance['host'] %>
+    port: <%= instance['port'] %>
+<% end -%>

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -387,6 +387,13 @@ sd_backend_port: <%= @sd_backend_port %>
 sd_template_dir: <%= @sd_template_dir %>
 <% end -%>
 
+# Enable JMX checks for service discovery
+<% if @sd_jmx_enable -%>
+sd_jmx_enable: <%= @sd_jmx_enable %>
+<% else -%>
+# sd_jmx_enable: no
+<% end -%>
+
 # If you Consul store requires token authentication for service discovery, you can define that token here.
 <% if @consul_token.empty? -%>
 # consul_token: f45cbd0b-5022-samp-le00-4eaa7c1f40f1

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -12,10 +12,10 @@ dd_url: <%= @dd_url %>
 <% else -%>
 proxy_host: <%= @proxy_host %>
 <% end -%>
-<% if @proxy_port.empty? -%>
+<% if @_proxy_port.empty? -%>
 # proxy_port:
 <% else -%>
-proxy_port: <%= @proxy_port %>
+proxy_port: <%= @_proxy_port %>
 <% end -%>
 <% if @proxy_user.empty? -%>
 # proxy_user:
@@ -85,17 +85,17 @@ recent_point_threshold: <%= @recent_point_threshold %>
 <% end -%>
 
 # Change port the Agent is listening to
-<% if @listen_port.empty? -%>
+<% if @_listen_port.empty? -%>
 # listen_port: 17123
 <% else -%>
-listen_port: <%= @listen_port %>
+listen_port: <%= @_listen_port %>
 <% end -%>
 
 # Start a graphite listener on this port
-<% if @graphite_listen_port.empty? -%>
+<% if @_graphite_listen_port.empty? -%>
 # graphite_listen_port: 17124
 <% else -%>
-graphite_listen_port: <%= @graphite_listen_port %>
+graphite_listen_port: <%= @_graphite_listen_port %>
 <% end -%>
 
 # Additional directory to look for Datadog checks
@@ -134,10 +134,10 @@ bind_host: <%= @bind_host %>
 
 use_pup: <%= @use_pup ? "yes" : "no" %>
 
-<% if @pup_port.empty? -%>
+<% if @_pup_port.empty? -%>
 # pup_port: 17125
 <% else -%>
-pup_port: <%= @pup_port %>
+pup_port: <%= @_pup_port %>
 <% end -%>
 
 <% if @pup_interface.empty? -%>
@@ -200,10 +200,10 @@ histogram_percentiles: <%= @statsd_histogram_percentiles %>
 <% else -%>
 statsd_forward_host: <%= @statsd_forward_host %>
 <% end -%>
-<% if @statsd_forward_port.empty? -%>
+<% if @_statsd_forward_port.empty? -%>
 # statsd_forward_port: 8125
 <% else -%>
-statsd_forward_port: <%= @statsd_forward_port %>
+statsd_forward_port: <%= @_statsd_forward_port %>
 <% end -%>
 
 # ========================================================================== #
@@ -340,10 +340,10 @@ log_to_syslog: <%= @log_to_syslog ? "yes" : "no" %>
 syslog_host: <%= @syslog_host  %>
 <% end -%>
 
-<% if @syslog_port.empty? -%>
+<% if @_syslog_port.empty? -%>
 # syslog_port:
 <% else -%>
-syslog_port: <%= @syslog_port  %>
+syslog_port: <%= @_syslog_port  %>
 <% end -%>
 
 

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -401,6 +401,11 @@ sd_jmx_enable: <%= @sd_jmx_enable %>
 consul_token: <%= @consul_token %>
 <% end -%>
 
+# ========================================================================== #
+# Trace                                                                      #
+# ========================================================================== #
+
+apm_enabled: <%= @apm_enabled %>
 
 <% if not @extra_template.empty? -%>
 

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -414,3 +414,8 @@ apm_enabled: <%= @apm_enabled %>
 # ========================================================================== #
 
 <% end -%>
+
+<% if not @apm_env.empty? -%>
+[trace.agent]
+env: <%= @apm_env %>
+<% end -%>

--- a/templates/datadog.list.erb
+++ b/templates/datadog.list.erb
@@ -1,0 +1,5 @@
+#
+# Datadog dd-agent repository: managed by puppet
+#
+
+deb <%= @location %> <%= @release %> <%= @repos %>

--- a/templates/datadog_apm_footer.conf.erb
+++ b/templates/datadog_apm_footer.conf.erb
@@ -1,0 +1,4 @@
+<% if not @apm_env.empty? -%>
+[trace.agent]
+env: <%= @apm_env %>
+<% end -%>

--- a/templates/datadog_footer.conf.erb
+++ b/templates/datadog_footer.conf.erb
@@ -1,67 +1,3 @@
-#
-# MANAGED BY PUPPET
-#
-[Main]
-
-# The host of the Datadog intake server to send agent data to
-dd_url: <%= @dd_url %>
-
-# If you need a proxy to connect to the Internet, provide the settings here
-<% if @proxy_host.empty? -%>
-# proxy_host:
-<% else -%>
-proxy_host: <%= @proxy_host %>
-<% end -%>
-<% if @_proxy_port.empty? -%>
-# proxy_port:
-<% else -%>
-proxy_port: <%= @_proxy_port %>
-<% end -%>
-<% if @proxy_user.empty? -%>
-# proxy_user:
-<% else -%>
-proxy_user: <%= @proxy_user %>
-<% end -%>
-<% if @proxy_password.empty? -%>
-# proxy_password:
-<% else -%>
-proxy_password: <%= @proxy_password %>
-<% end -%>
-
-# If you run the agent behind haproxy, you might want to set this to yes
-<% if @skip_ssl_validation -%>
-skip_ssl_validation: <%= @skip_ssl_validation %>
-<% else -%>
-# skip_ssl_validation: no
-<% end -%>
-
-# The Datadog api key to associate your Agent's data with your organization.
-# Can be found here:
-# https://app.datadoghq.com/account/settings
-api_key: <%= @api_key %>
-
-# Force the hostname to whatever you want.
-<% if @host.empty? -%>
-# hostname:
-<% else -%>
-hostname: <%= @host %>
-<% end -%>
-
-# Set the host's tags
-#tags: mytag0, mytag1
-<%
-tag_list = @local_tags
-@facts_to_tags.each do |f|
-  value = scope.lookupvar(f)
-  if not value.nil?
-    tag = "#{f}:#{value}"
-    tag_list << tag
-  end
-end
-if not tag_list.empty?
--%>
-tags: <%= tag_list.join(', ') %>
-<% end -%>
 
 # Collect AWS EC2 custom tags as agent tags
 collect_ec2_tags: <%= @collect_ec2_tags %>
@@ -124,6 +60,7 @@ use_curl_http_client: <%= @use_curl_http_client %>
 bind_host: <%= @bind_host %>
 <% end -%>
 
+
 # ========================================================================== #
 # Pup configuration
 # ========================================================================== #
@@ -163,10 +100,10 @@ use_dogstatsd: <%= @use_dogstatsd ? "yes" : "no" %>
 # usage information, check out http://api.datadoghq.com
 
 #  Make sure your client is sending to the same port.
-<% if @dogstatsd_port.nil? -%>
+<% if @_dogstatsd_port.empty? -%>
 # dogstatsd_port: 8125
 <% else -%>
-dogstatsd_port: <%= @dogstatsd_port %>
+dogstatsd_port: <%= @_dogstatsd_port %>
 <% end -%>
 
 # By default dogstatsd will post aggregate metrics to the Agent (which handles
@@ -390,8 +327,6 @@ sd_template_dir: <%= @sd_template_dir %>
 # Enable JMX checks for service discovery
 <% if @sd_jmx_enable -%>
 sd_jmx_enable: <%= @sd_jmx_enable %>
-<% else -%>
-# sd_jmx_enable: no
 <% end -%>
 
 # If you Consul store requires token authentication for service discovery, you can define that token here.
@@ -405,17 +340,13 @@ consul_token: <%= @consul_token %>
 # Trace                                                                      #
 # ========================================================================== #
 
+# Enable the trace agent.
 apm_enabled: <%= @apm_enabled %>
 
-<% if not @extra_template.empty? -%>
 
+<% if not @extra_template.empty? -%>
 # ========================================================================== #
 # Custom Templates from Puppet                                               #
 # ========================================================================== #
 
-<% end -%>
-
-<% if not @apm_env.empty? -%>
-[trace.agent]
-env: <%= @apm_env %>
 <% end -%>

--- a/templates/datadog_header.conf.erb
+++ b/templates/datadog_header.conf.erb
@@ -1,0 +1,48 @@
+#
+# MANAGED BY PUPPET
+#
+[Main]
+
+# The host of the Datadog intake server to send agent data to
+dd_url: <%= @dd_url %>
+
+# If you need a proxy to connect to the Internet, provide the settings here
+<% if @proxy_host.empty? -%>
+# proxy_host:
+<% else -%>
+proxy_host: <%= @proxy_host %>
+<% end -%>
+<% if @_proxy_port.empty? -%>
+# proxy_port:
+<% else -%>
+proxy_port: <%= @_proxy_port %>
+<% end -%>
+<% if @proxy_user.empty? -%>
+# proxy_user:
+<% else -%>
+proxy_user: <%= @proxy_user %>
+<% end -%>
+<% if @proxy_password.empty? -%>
+# proxy_password:
+<% else -%>
+proxy_password: <%= @proxy_password %>
+<% end -%>
+
+# If you run the agent behind haproxy, you might want to set this to yes
+<% if @skip_ssl_validation -%>
+skip_ssl_validation: <%= @skip_ssl_validation %>
+<% else -%>
+# skip_ssl_validation: no
+<% end -%>
+
+# The Datadog api key to associate your Agent's data with your organization.
+# Can be found here:
+# https://app.datadoghq.com/account/settings
+api_key: <%= @api_key %>
+
+# Force the hostname to whatever you want.
+<% if @host.empty? -%>
+# hostname:
+<% else -%>
+hostname: <%= @host %>
+<% end -%>


### PR DESCRIPTION
This will update the Datadog puppet module we have forked to the current upstream 1.11.0 release.

I have updated the `master` branch, but the environments run off the `staging` and `production` branches. So it will need to be merged into each as we do with normal Puppet.

Upstream change log https://github.com/DataDog/puppet-datadog-agent/blob/master/CHANGELOG.md